### PR TITLE
Refactor: Harden server accounting, logging, and tests

### DIFF
--- a/config.default.jsonc
+++ b/config.default.jsonc
@@ -64,7 +64,7 @@
 
   /**
     The software will use verbosity according to log_level.
-    Supported levels: none < error < warn < info < log.
+    Supported levels: none < error < warn < info < log < debug.
   **/
   "log_level": "log",
 

--- a/server/src/api/index.js
+++ b/server/src/api/index.js
@@ -10,6 +10,10 @@ import store from '../modules/store.js';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const publicDir = join(__dirname, '../../../web/dist/');
 
+/**
+ * Read-only Express app that serves the web dashboard and the public pool JSON API.
+ * All routes are GET-only; no endpoint exposes secrets or accepts state changes.
+ */
 const app = express();
 
 app.use(cors({
@@ -27,20 +31,24 @@ app.use('/', express.static(publicDir));
 
 app.get('/', (req, res) => res.sendFile(join(publicDir, 'index.html')));
 
+// Returns all recorded payout transactions.
 app.get('/api/transactions', async (req, res) => {
   const transactions = await mongo.transactionsCollection.find({}).toArray();
 
   return res.send(transactions);
 });
 
+// Returns all voters with their accumulated and pending rewards.
 app.get('/api/voters', async (req, res) => {
   const voters = await mongo.votersCollection.find({}).toArray();
 
   return res.send(voters);
 });
 
+// Returns the in-memory delegate/period state snapshot.
 app.get('/api/delegate', async (req, res) => res.send(store));
 
+// Returns the public pool configuration and current period summary.
 app.get('/api/config', async (req, res) => res.send({
   version: config.version,
   reward_percentage: config.reward_percentage,

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -4,9 +4,9 @@ import { EXIT_CODE_ERROR, UPDATE_BLOCKS_INTERVAL } from './defines.js';
 import { adamantApiClient, config, log, notifier } from './helpers/index.js';
 import payoutCron from './cron/payout.cron.js';
 
-import store, { formatDelegateName } from './modules/store.js';
 import blocksChecker from './modules/blocks_checker.js';
 import server from './api/index.js';
+import store from './modules/store.js';
 
 log.start();
 
@@ -35,16 +35,14 @@ adamantApiClient.onReady(async () => {
  * @returns {Promise<void>}
  */
 async function initDelegate() {
+  // updateDelegate() sets config.logName/poolName once the account is confirmed to be a delegate.
   const pool = await store.updateDelegate();
 
-  if (pool) {
-    config.poolName = pool.username;
-  } else {
+  if (!pool) {
     log.error(`Failed to get delegate for ${config.address}. Cannot start Pool.`);
     process.exit(EXIT_CODE_ERROR);
   }
 
-  config.logName = `${formatDelegateName(config.poolName)} (${config.address})`;
   config.infoString = `distributes _${config.reward_percentage}_% rewards to voters` +
     `${config.donate_percentage ? ' and donates ' + config.donate_percentage + '% to ADAMANT developer community' : ''} ` +
     `with payouts every _${config.payoutperiod}_. Minimum payout is _${config.minpayout}_ ADM.`;

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -17,7 +17,7 @@ try {
 }
 
 server.listen(config.port, () => (
-  log.log(`Pool ${config.address} successfully started the web server.`)
+  log.log(`Pool ${config.address} successfully started the web server on port ${config.port}.`)
 ));
 
 // Wait for first API health check

--- a/server/src/cron/payout.cron.js
+++ b/server/src/cron/payout.cron.js
@@ -18,6 +18,12 @@ const DAYS_OF_WEEK = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
 export default {
   cronJob: {},
+  /**
+   * Starts the payout cron job for the configured payout period.
+   * @param {string} payoutPeriod Payout period: a day name (e.g. `Mon`) or interval key (`1h`, `1d`, `5d`, `10d`, `15d`, `30d`)
+   * @returns {void}
+   * @throws {Error} When the payout period does not map to a valid cron pattern
+   */
   init(payoutPeriod) {
     try {
       let cronTime;

--- a/server/src/cron/payout.cron.js
+++ b/server/src/cron/payout.cron.js
@@ -48,7 +48,7 @@ export default {
       log.info('Payout cron job has been started.');
     } catch (error) {
       log.error(
-          `Pool's ${config.address} config is wrong. Failed to validate payoutperiod: `+
+          `Pool's ${config.address} config is wrong. Failed to validate 'payoutperiod': `+
           `${payoutPeriod}${error ? ', ' + error : ''}. Cannot start Pool.`,
       );
 

--- a/server/src/helpers/adamantApiClient.js
+++ b/server/src/helpers/adamantApiClient.js
@@ -3,6 +3,13 @@ import { AdamantApi } from 'adamant-api';
 import config from './config/reader.js';
 import log from './log.js';
 
+/**
+ * Shared ADAMANT API client.
+ *
+ * Configured with the pool's node list and automatic failover (`maxRetries`),
+ * a startup health check, and the pool logger so request diagnostics honor
+ * `config.log_level`.
+ */
 export default new AdamantApi({
   nodes: config.node_ADM,
   timeout: 10_000,

--- a/server/src/helpers/config/reader.js
+++ b/server/src/helpers/config/reader.js
@@ -84,6 +84,10 @@ const address = createAddressFromPublicKey(keysPair.publicKey);
 config.publicKey = keysPair.publicKey.toString('hex');
 config.address = address;
 
+// Until the delegate is fetched, identify the pool by address only — the account
+// may not be a delegate yet. store.updateDelegate() upgrades this to `'name' (address)`.
+config.logName = address;
+
 const errorMessage = validateConfig(config, configSchema);
 
 if (errorMessage) {

--- a/server/src/helpers/config/schema.js
+++ b/server/src/helpers/config/schema.js
@@ -50,6 +50,7 @@ export default {
   log_level: {
     type: String,
     default: 'log',
+    allowedValues: ['none', 'error', 'warn', 'info', 'log', 'debug'],
   },
   silent_mode: {
     type: Boolean,

--- a/server/src/helpers/config/validate.js
+++ b/server/src/helpers/config/validate.js
@@ -18,5 +18,9 @@ export default (config, schema) => {
     if (configProperty && field.type !== configProperty.__proto__.constructor) {
       return `Pool's ${config.address} config is wrong. Field type _${fieldName}_ is not valid, expected type is _${field.type.name}_. Cannot start Pool.`;
     }
+
+    if (field.allowedValues && !field.allowedValues.includes(config[fieldName])) {
+      return `Pool's ${config.address} config is wrong. Field _${fieldName}_ must be one of: ${field.allowedValues.join(', ')}. Cannot start Pool.`;
+    }
   }
 };

--- a/server/src/helpers/log.js
+++ b/server/src/helpers/log.js
@@ -11,6 +11,23 @@ const infoStr = fs.createWriteStream(`./logs/${date()}.log`, {
   flags: 'a',
 });
 
+const LOG_LEVELS = {
+  none: 0,
+  error: 1,
+  warn: 2,
+  info: 3,
+  log: 4,
+  debug: 5,
+};
+
+const LOG_COLORS = {
+  error: '\x1b[31m',
+  warn: '\x1b[33m',
+  info: '\x1b[32m',
+  log: '\x1b[34m',
+  debug: '\x1b[36m',
+};
+
 export default {
   /**
    * Writes the pool start marker into the current log file.
@@ -25,10 +42,7 @@ export default {
    * @returns {void}
    */
   error(str) {
-    if (['error', 'warn', 'info', 'log'].includes(config.log_level)) {
-      infoStr.write('\n ' + 'error|' + fullTime() + '|' + str);
-      console.log('\x1b[31m', 'error|' + fullTime(), '\x1b[0m', str);
-    }
+    writeLog('error', str);
   },
   /**
    * Logs a warning message.
@@ -36,10 +50,7 @@ export default {
    * @returns {void}
    */
   warn(str) {
-    if (['warn', 'info', 'log'].includes(config.log_level)) {
-      console.log('\x1b[33m', 'warn|' + fullTime(), '\x1b[0m', str);
-      infoStr.write('\n ' + 'warn|' + fullTime() + '|' + str);
-    }
+    writeLog('warn', str);
   },
   /**
    * Logs an informational message.
@@ -47,10 +58,7 @@ export default {
    * @returns {void}
    */
   info(str) {
-    if (['info', 'log'].includes(config.log_level)) {
-      console.log('\x1b[32m', 'info|' + fullTime(), '\x1b[0m', str);
-      infoStr.write('\n ' + 'info|' + fullTime() + '|' + str);
-    }
+    writeLog('info', str);
   },
   /**
    * Logs a verbose operational message.
@@ -58,21 +66,64 @@ export default {
    * @returns {void}
    */
   log(str) {
-    if (['log'].includes(config.log_level)) {
-      console.log('\x1b[34m', 'log|' + fullTime(), '\x1b[0m', str);
-      infoStr.write('\n ' + 'log|' + fullTime() + '|' + str);
-    }
+    writeLog('log', str);
+  },
+  /**
+   * Logs detailed diagnostics for troubleshooting operational flows.
+   * @param {string} str Message to log
+   * @returns {void}
+   */
+  debug(str) {
+    writeLog('debug', str);
   },
 };
 
+/**
+ * Checks whether a message level is enabled by the configured pool verbosity.
+ * @param {'error'|'warn'|'info'|'log'|'debug'} type Message severity to evaluate
+ * @returns {boolean} Whether the message should be written
+ */
+function shouldLog(type) {
+  return (LOG_LEVELS[config.log_level] ?? LOG_LEVELS.none) >= LOG_LEVELS[type];
+}
+
+/**
+ * Writes a message to the console and the active log file.
+ * @param {'error'|'warn'|'info'|'log'|'debug'} type Message severity to write
+ * @param {string} str Message to log
+ * @returns {void}
+ */
+function writeLog(type, str) {
+  if (!shouldLog(type)) {
+    return;
+  }
+
+  const timestamp = fullTime();
+
+  infoStr.write('\n ' + type + '|' + timestamp + '|' + str);
+  console.log(LOG_COLORS[type], type + '|' + timestamp, '\x1b[0m', str);
+}
+
+/**
+ * Returns the current time formatted for log entries.
+ * @returns {string} Time in HH:mm:ss format
+ */
 function time() {
   return utils.formatDate(Date.now()).hh_mm_ss;
 }
 
+/**
+ * Returns the current date formatted for the log file and entries.
+ * @returns {string} Date in YYYY-MM-DD format
+ */
 function date() {
   return utils.formatDate(Date.now()).YYYY_MM_DD;
 }
 
+/**
+ * Returns the current date and time formatted for log entries.
+ * @returns {string} Date and time in YYYY-MM-DD HH:mm:ss format
+ */
 function fullTime() {
   return date() + ' ' + time();
 }

--- a/server/src/helpers/notify.js
+++ b/server/src/helpers/notify.js
@@ -11,13 +11,17 @@ const {
 /**
  * Logs a message and sends configured ADAMANT or Slack notifications.
  * @param {string} message Notification message
- * @param {'error'|'warn'|'info'|'log'} type Notification severity
+ * @param {'error'|'warn'|'info'|'log'|'debug'} type Notification severity
  * @param {boolean} [silentMode=false] Whether to skip external notification channels
  * @returns {void}
  */
 export default (message, type, silentMode = false) => {
   try {
     log[type](removeMarkdown(message));
+
+    if (type === 'debug') {
+      return;
+    }
 
     if (!silentMode) {
       if (!slack && !adamantNotify) {
@@ -29,6 +33,7 @@ export default (message, type, silentMode = false) => {
         warn: '#FFFF00',
         info: '#00FF00',
         log: '#FFFFFF',
+        debug: '#9CA3AF',
       };
 
       const color = colors[type];

--- a/server/src/helpers/notify.js
+++ b/server/src/helpers/notify.js
@@ -17,7 +17,7 @@ const {
  */
 export default (message, type, silentMode = false) => {
   try {
-    log[type](removeMarkdown(message));
+    log[type](`/Logging notify message/ ${removeMarkdown(message)}`);
 
     if (type === 'debug') {
       return;

--- a/server/src/helpers/utils.js
+++ b/server/src/helpers/utils.js
@@ -1,5 +1,11 @@
 import { EPOCH, SAT } from '../defines.js';
 
+/**
+ * Replaces `{token}` placeholders in a template with values from a date parts object.
+ * @param {string} text Template containing `{token}` placeholders
+ * @param {object} dateObject Map of token names to their replacement strings
+ * @returns {string} Template with placeholders substituted
+ */
 function replaceWithDate(text, dateObject) {
   return text.replace(/{([a-zA-Z_]*)}/g, (_, digit) => dateObject[digit]);
 }
@@ -39,10 +45,20 @@ export default {
     return epochTime * 1000 + EPOCH;
   },
 
+  /**
+   * Converts an amount in sats to a fixed-precision ADM string.
+   * @param {number|string} sats Amount in sats (1 ADM = 1e8 sats)
+   * @param {number} [decimals=8] Number of decimal places to keep
+   * @return {string} Amount in ADM, fixed to `decimals` places
+   */
   satsToADM(sats, decimals = 8) {
     return (+sats / SAT).toFixed(decimals);
   },
 
+  /**
+   * Returns the current Unix timestamp in milliseconds.
+   * @return {number}
+   */
   unix() {
     return Date.now();
   },
@@ -81,6 +97,12 @@ export default {
     return formattedDate;
   },
 
+  /**
+   * Formats a number with thin-space thousand separators, optionally bolding the integer part.
+   * @param {number|string} num Number to format
+   * @param {boolean} [doBold] Whether to wrap the integer part in Markdown bold markers
+   * @return {string} Formatted number string
+   */
   thousandSeparator(num, doBold) {
     const parts = (num + '').split('.');
     const main = parts[0];
@@ -105,10 +127,20 @@ export default {
     return output;
   },
 
+  /**
+   * Returns the smallest positive value representable at the given decimal precision.
+   * @param {number} decimals Number of decimal places
+   * @return {number} Precision step, e.g. `0.01` for 2 decimals
+   */
   getPrecision(decimals) {
     return +(Math.pow(10, -decimals).toFixed(decimals));
   },
 
+  /**
+   * Extracts the file name from a module path or id.
+   * @param {string} id Module path using `/` or `\` separators
+   * @return {string} Trailing file name, or an empty string when no separator is present
+   */
   getModuleName(id) {
     let n = id.lastIndexOf('\\');
 

--- a/server/src/modules/block_parser.js
+++ b/server/src/modules/block_parser.js
@@ -4,6 +4,10 @@ import { log } from '../helpers/index.js';
 import mongo from '../repository/mongodb/index.js';
 
 class QueueNode {
+  /**
+   * Creates a queue node for a forged block.
+   * @param {object} value Forged block queued for reward distribution
+   */
   constructor(value) {
     this.value = value;
     this.next = null;
@@ -11,6 +15,9 @@ class QueueNode {
 }
 
 class BlockParser {
+  /**
+   * Creates an in-memory FIFO queue for forged blocks awaiting parsing.
+   */
   constructor() {
     this.queue = {};
     this.length = 0;
@@ -25,10 +32,20 @@ class BlockParser {
     return this.length === 0;
   }
 
+  /**
+   * Checks whether a block id is already queued.
+   * @param {string|number} blockId Block id returned by the ADAMANT node API
+   * @returns {boolean} Whether the block is already queued
+   */
   queued(blockId) {
     return !!this.queue[blockId];
   }
 
+  /**
+   * Adds a forged block to the queue unless it is already queued.
+   * @param {object} block Forged block returned by the ADAMANT node API
+   * @returns {void}
+   */
   enqueue(block) {
     const { id } = block;
 
@@ -48,6 +65,10 @@ class BlockParser {
     }
   }
 
+  /**
+   * Removes and returns the next queued block.
+   * @returns {object|undefined} Next block when the queue is not empty
+   */
   dequeue() {
     if (!this.isEmpty) {
       const { value: block } = this.head;
@@ -69,6 +90,10 @@ class BlockParser {
     }
   }
 
+  /**
+   * Parses queued blocks sequentially while preventing overlapping runs.
+   * @returns {Promise<void>}
+   */
   async run() {
     if (!this.isEmpty && !this.isLocked) {
       this.isLocked = true;
@@ -89,10 +114,13 @@ class BlockParser {
     }
   }
 
+  /**
+   * Saves a new block or retries reward distribution for an unprocessed block.
+   * @param {object} block Forged block returned by the ADAMANT node API
+   * @returns {Promise<void>}
+   */
   async parse(block) {
     const { id, height } = block;
-
-    const rewardDistributor = new RewardDistributor(block);
 
     let savedBlock;
     try {
@@ -106,13 +134,22 @@ class BlockParser {
       if (!savedBlock.processed) {
         log.info(`Re-trying to distribute rewards for block ${id} (height ${height})…`);
 
+        const rewardDistributor = new RewardDistributor({
+          ...block,
+          ...savedBlock,
+        });
+
         await rewardDistributor.distribute();
       }
     } else {
       log.info(`New block forged: ${id} (height ${height}).`);
 
       try {
-        await mongo.blocksCollection.insertOne(block);
+        await mongo.blocksCollection.insertOne({
+          ...block,
+          processed: false,
+          rewardedAddresses: [],
+        });
       } catch (error) {
         log.error(`Failed to parse block ${id} with height ${height}: ${error}`);
         return;
@@ -121,6 +158,12 @@ class BlockParser {
       log.info(
           `Block successfully saved: ${id} (height ${height}). Distributing rewards…`,
       );
+
+      const rewardDistributor = new RewardDistributor({
+        ...block,
+        processed: false,
+        rewardedAddresses: [],
+      });
 
       await rewardDistributor.distribute();
     }

--- a/server/src/modules/block_parser.js
+++ b/server/src/modules/block_parser.js
@@ -103,7 +103,7 @@ class BlockParser {
       try {
         await this.parse(block);
       } catch (error) {
-        const errorTemplate = `Error while processing ${block.id} (height ${block.height})`;
+        const errorTemplate = `Error while processing block ${block.id} (height ${block.height})`;
 
         log.error(`${errorTemplate}: ${error}`);
       }
@@ -126,7 +126,7 @@ class BlockParser {
     try {
       savedBlock = await mongo.blocksCollection.findOne({ id });
     } catch (error) {
-      log.error(`Failed to parse block ${id} with height ${height}: ${error}`);
+      log.error(`Failed to parse block ${id} at height ${height}: ${error}`);
       return;
     }
 
@@ -151,12 +151,12 @@ class BlockParser {
           rewardedAddresses: [],
         });
       } catch (error) {
-        log.error(`Failed to parse block ${id} with height ${height}: ${error}`);
+        log.error(`Failed to parse block ${id} at height ${height}: ${error}`);
         return;
       }
 
       log.info(
-          `Block successfully saved: ${id} (height ${height}). Distributing rewards…`,
+          `Forged block successfully stored: ${id} (height ${height}). Distributing rewards…`,
       );
 
       const rewardDistributor = new RewardDistributor({

--- a/server/src/modules/blocks_checker.js
+++ b/server/src/modules/blocks_checker.js
@@ -15,16 +15,16 @@ async function checkBlocks() {
     if (getBlocksResponse.success) {
       const { blocks } = getBlocksResponse;
 
-      log.debug(`Fetched last ${blocks.length} blocks forged by delegate ${config.address}.`);
+      log.debug(`Fetched last ${blocks.length} blocks forged by delegate ${config.logName}.`);
 
       blocks.forEach((block) => blockParser.enqueue(block));
 
       await blockParser.run();
     } else {
-      log.warn(`Failed to get blocks forged by delegate ${config.address}. ${getBlocksResponse.errorMessage}.`);
+      log.warn(`Failed to get blocks forged by delegate ${config.logName}. ${getBlocksResponse.errorMessage}.`);
     }
   } catch (error) {
-    log.error(`Error while checking blocks forged by delegate ${config.address}: ${error}`);
+    log.error(`Error while checking blocks forged by delegate ${config.logName}: ${error}`);
   }
 }
 

--- a/server/src/modules/blocks_checker.js
+++ b/server/src/modules/blocks_checker.js
@@ -4,12 +4,19 @@ import { adamantApiClient, config, log } from '../helpers/index.js';
 
 const blockParser = new BlockParser();
 
+/**
+ * Fetches recent delegate blocks and passes them through the reward parser queue.
+ * @returns {Promise<void>}
+ */
 async function checkBlocks() {
   try {
     const getBlocksResponse = await adamantApiClient.getBlocks({ limit: 100, generatorPublicKey: config.publicKey });
 
     if (getBlocksResponse.success) {
       const { blocks } = getBlocksResponse;
+
+      log.debug(`Fetched ${blocks.length} forged blocks for delegate ${config.address}.`);
+
       blocks.forEach((block) => blockParser.enqueue(block));
 
       await blockParser.run();

--- a/server/src/modules/blocks_checker.js
+++ b/server/src/modules/blocks_checker.js
@@ -15,16 +15,16 @@ async function checkBlocks() {
     if (getBlocksResponse.success) {
       const { blocks } = getBlocksResponse;
 
-      log.debug(`Fetched ${blocks.length} forged blocks for delegate ${config.address}.`);
+      log.debug(`Fetched last ${blocks.length} blocks forged by delegate ${config.address}.`);
 
       blocks.forEach((block) => blockParser.enqueue(block));
 
       await blockParser.run();
     } else {
-      log.warn(`Failed to get blocks. ${getBlocksResponse.errorMessage}.`);
+      log.warn(`Failed to get blocks forged by delegate ${config.address}. ${getBlocksResponse.errorMessage}.`);
     }
   } catch (error) {
-    log.error(`Error while checking new blocks: ${error}`);
+    log.error(`Error while checking blocks forged by delegate ${config.address}: ${error}`);
   }
 }
 

--- a/server/src/modules/distribute_rewards.js
+++ b/server/src/modules/distribute_rewards.js
@@ -151,6 +151,18 @@ class RewardDistributor {
               `${voter.address}. userWeight: ${userWeightInADM} ADM (${user.percent.toFixed(2)}%).`,
           );
 
+          // Persist this voter's progress on the block right after paying it, so a crash or
+          // retry cannot add the same block reward to the voter twice (see recordVoterOnBlock).
+          try {
+            await this.recordVoterOnBlock(voter.address, user);
+          } catch (error) {
+            log.error(
+                `Failed to record reward progress for ${voter.address} on block ${block.id} ` +
+                `(height ${block.height}): ${error}`,
+            );
+            return;
+          }
+
           distributed.votersCount += 1;
           distributed.rewardsADM += user.reward;
           distributed.percent += user.percent;
@@ -165,23 +177,50 @@ class RewardDistributor {
   }
 
   /**
-   * Stores block-level reward distribution progress.
+   * Atomically records a single voter's reward progress on the block document.
+   *
+   * Called right after the voter's pending reward is stored, so the block always
+   * reflects who has already been paid. `$addToSet` keeps the record idempotent on
+   * retries and `$inc` keeps the block counters correct while voters are distributed
+   * in parallel. This shrinks the duplicate-reward window to the gap between the
+   * voter update and this single block update, instead of the whole distribution run.
+   *
+   * @param {string} address Voter address that was just rewarded on this block
+   * @param {{reward: number, percent: number}} user Reward computed for the voter
+   * @returns {Promise<void>}
+   */
+  async recordVoterOnBlock(address, user) {
+    const { block } = this;
+
+    await mongo.blocksCollection.updateOne(
+        { id: block.id },
+        {
+          $addToSet: { rewardedAddresses: address },
+          $inc: {
+            votersCount: 1,
+            rewardsADM: user.reward,
+            percent: user.percent,
+          },
+        },
+    );
+  }
+
+  /**
+   * Marks the block processed once every eligible voter has been accounted for.
+   *
+   * Per-voter progress (`rewardedAddresses` and counters) is persisted incrementally
+   * in {@link recordVoterOnBlock}, so this only needs to flip the processed flag.
+   *
    * @param {boolean} processed Whether every eligible voter has been accounted for
-   * @returns {Promise<boolean>} Whether the block progress was saved
+   * @returns {Promise<boolean>} Whether the block flag was saved
    */
   async updateBlockDistribution(processed) {
-    const { block, distributed, rewardedAddresses } = this;
+    const { block, distributed } = this;
 
     try {
       await mongo.blocksCollection.updateOne(
           { id: block.id },
-          {
-            $set: {
-              processed,
-              ...distributed,
-              rewardedAddresses: [...rewardedAddresses],
-            },
-          },
+          { $set: { processed } },
       );
 
       log.debug(

--- a/server/src/modules/distribute_rewards.js
+++ b/server/src/modules/distribute_rewards.js
@@ -62,16 +62,16 @@ class RewardDistributor {
 
         log.info(
             `Block ${block.id} (height ${block.height}) rewards successfully updated — ` +
-            `${votersCount} of ${eligibleVotersCount} eligible voters, ` +
-            `distributedRewards: ${rewardsADM.toFixed(4)} ADM (${percent.toFixed(2)}%).`,
+            `${votersCount} of ${eligibleVotersCount} eligible voters. ` +
+            `Distributed rewards: ${rewardsADM.toFixed(4)} ADM (${percent.toFixed(2)}%).`,
         );
       } else {
         const { distributed, eligibleVotersCount, blockTotalForged } = this;
         const blockTotalForgedInADM = utils.satsToADM(blockTotalForged * config.reward_percentage / 100, 4);
 
         this.notifyRewardsOnBlock(
-            `distributed partially — ${distributed.votersCount} of ${eligibleVotersCount} eligible voters, ` +
-            `distributedRewards: ${distributed.rewardsADM.toFixed(4)} of ${blockTotalForgedInADM} ADM. Check logs.`,
+            `Block ${block.id} (height ${block.height}) rewards distributed partially — ${distributed.votersCount} of ${eligibleVotersCount} eligible voters. ` +
+            `Distributed rewards: ${distributed.rewardsADM.toFixed(4)} of ${blockTotalForgedInADM} ADM. Check log for details.`,
             'warn',
         );
       }

--- a/server/src/modules/distribute_rewards.js
+++ b/server/src/modules/distribute_rewards.js
@@ -3,7 +3,7 @@ import {
   SAT,
 } from '../defines.js';
 
-import store from './store.js';
+import store, { normalizePendingReward } from './store.js';
 
 import { config, log, notifier, utils } from '../helpers/index.js';
 import mongo from '../repository/mongodb/index.js';
@@ -18,10 +18,11 @@ class RewardDistributor {
     this.blockTotalForged = +block.totalForged;
 
     this.distributed = {
-      rewardsADM: 0,
-      votersCount: 0,
-      percent: 0,
+      rewardsADM: Number(block.rewardsADM) || 0,
+      votersCount: Number(block.votersCount) || 0,
+      percent: Number(block.percent) || 0,
     };
+    this.rewardedAddresses = new Set(block.rewardedAddresses ?? []);
 
     this.voters = store.delegate.voters;
     this.votesWeight = store.delegate.votesWeight;
@@ -50,27 +51,29 @@ class RewardDistributor {
 
       await Promise.all(distributionPromises);
 
+      const isComplete = this.distributed.votersCount === this.eligibleVotersCount;
+      const isBlockUpdated = await this.updateBlockDistribution(isComplete);
+
+      this.isDistributionComplete = isComplete && isBlockUpdated;
+
       if (this.isDistributionComplete) {
-        const { distributed, eligibleVotersCount, blockTotalForged } = this;
+        const { distributed, eligibleVotersCount } = this;
         const { votersCount, rewardsADM, percent } = distributed;
 
-        if (distributed.votersCount === eligibleVotersCount) {
-          log.info(
-              `Block ${block.id} (height ${block.height}) rewards successfully updated — ` +
-              `${votersCount} of ${eligibleVotersCount} eligible voters, ` +
-              `distributedRewards: ${rewardsADM.toFixed(4)} ADM (${percent.toFixed(2)}%).`,
-          );
-        } else {
-          const blockTotalForgedInADM = utils.satsToADM(blockTotalForged * config.reward_percentage / 100, 4);
-
-          this.notifyRewardsOnBlock(
-              `distributed partially — ${votersCount} of ${eligibleVotersCount} eligible voters, ` +
-              `distributedRewards: ${rewardsADM.toFixed(4)} of ${blockTotalForgedInADM} ADM.`,
-              'warn',
-          );
-        }
+        log.info(
+            `Block ${block.id} (height ${block.height}) rewards successfully updated — ` +
+            `${votersCount} of ${eligibleVotersCount} eligible voters, ` +
+            `distributedRewards: ${rewardsADM.toFixed(4)} ADM (${percent.toFixed(2)}%).`,
+        );
       } else {
-        this.notifyRewardsOnBlock('could not be distributed. Check logs.', 'error');
+        const { distributed, eligibleVotersCount, blockTotalForged } = this;
+        const blockTotalForgedInADM = utils.satsToADM(blockTotalForged * config.reward_percentage / 100, 4);
+
+        this.notifyRewardsOnBlock(
+            `distributed partially — ${distributed.votersCount} of ${eligibleVotersCount} eligible voters, ` +
+            `distributedRewards: ${distributed.rewardsADM.toFixed(4)} of ${blockTotalForgedInADM} ADM. Check logs.`,
+            'warn',
+        );
       }
     }
   }
@@ -108,12 +111,20 @@ class RewardDistributor {
       if (isVoterEligible) {
         this.eligibleVotersCount += 1;
 
+        if (this.rewardedAddresses.has(voter.address)) {
+          log.debug(
+              `Skipping reward distribution for ${voter.address} on block ${block.id} ` +
+              `(height ${block.height}) because the voter is already recorded for this block.`,
+          );
+          return;
+        }
+
         const dbVoter = await this.findOrCreateVoter(voter);
 
         if (dbVoter) {
           const user = this.calcVoterReward(voterBalance, votesCount, votesWeight);
 
-          const pending = dbVoter.pending + user.reward;
+          const pending = normalizePendingReward(dbVoter) + user.reward;
 
           // Keep existing DB field names for compatibility with stored voter records.
           try {
@@ -143,29 +154,46 @@ class RewardDistributor {
           distributed.votersCount += 1;
           distributed.rewardsADM += user.reward;
           distributed.percent += user.percent;
-
-          // Mark block processed, if any voter gets reward
-          try {
-            await mongo.blocksCollection.updateOne(
-                { id: block.id },
-                {
-                  $set: {
-                    processed: true,
-                    ...distributed,
-                  },
-                });
-          } catch (error) {
-            log.error(`Error while distributing rewards for ${voter.address} on block ${block.id} (height ${block.height}): ${error}`);
-            return;
-          }
-
-          this.isDistributionComplete = true;
+          this.rewardedAddresses.add(voter.address);
         }
       }
     } catch (error) {
       log.error(
           `Error while distributing rewards for ${voter.address} on block ${block.id} (height ${block.height}): ${error}`,
       );
+    }
+  }
+
+  /**
+   * Stores block-level reward distribution progress.
+   * @param {boolean} processed Whether every eligible voter has been accounted for
+   * @returns {Promise<boolean>} Whether the block progress was saved
+   */
+  async updateBlockDistribution(processed) {
+    const { block, distributed, rewardedAddresses } = this;
+
+    try {
+      await mongo.blocksCollection.updateOne(
+          { id: block.id },
+          {
+            $set: {
+              processed,
+              ...distributed,
+              rewardedAddresses: [...rewardedAddresses],
+            },
+          },
+      );
+
+      log.debug(
+          `Saved reward distribution progress for block ${block.id} (height ${block.height}): ` +
+          `${distributed.votersCount} voters, processed=${processed}.`,
+      );
+
+      return true;
+    } catch (error) {
+      log.error(`Failed to save reward distribution progress for block ${block.id} (height ${block.height}): ${error}`);
+
+      return false;
     }
   }
 

--- a/server/src/modules/pay_out.js
+++ b/server/src/modules/pay_out.js
@@ -35,7 +35,7 @@ class Payer {
     const infoString = this.getBaseInfoString(balance);
 
     if (!votersToReward.length) {
-      return notifier(`Pool ${config.logName}: No pending payouts.\n${infoString}`, 'warn');
+      return notifier(`Pool ${config.logName}: No pending reward payouts.\n${infoString}`, 'warn');
     }
 
     const { retryNo } = this;
@@ -43,20 +43,19 @@ class Payer {
 
     if (pendingUserRewards > balance) {
       notifier(
-          `Pool ${config.logName}: Unable to do payouts, retryNo: ${retryNo}. ` +
-          `The pool balance is lower than pending payouts. Top up the pool balance.\n${infoString}`,
+          `Pool ${config.logName}: Unable to do reward payouts, retry #${retryNo}. ` +
+          `The pool balance is lower than pending payout amount. Top up pool balance.\n${infoString}`,
           'error',
       );
 
       return this.retry();
     }
 
-    notifier(
-        retryNo ?
-          `Pool ${config.logName}: Retrying payouts (${nextRetryNo} of ${RETRY_PAYOUTS_COUNT + 1}).` :
-          `Pool ${config.logName}: Ready to process scheduled payouts.\n${infoString}`,
-        'log',
-    );
+    if (retryNo > 0) {
+      log.log(`Retrying reward payouts (${nextRetryNo}/${RETRY_PAYOUTS_COUNT + 1}). ${infoString}`);
+    } else {
+      log.info(`Ready to process scheduled reward payouts. ${infoString}`);
+    }
 
     const {
       paidUserRewards,
@@ -82,7 +81,7 @@ class Payer {
 
     const notifyType = isEveryRewardSaved ? 'log' : 'warn';
 
-    let payoutInfoString = `I ${isEveryVoterRewarded ? 'successfully ' : ''}paid ${isEveryRewardSaved ? 'and saved ' : ''}`;
+    let payoutInfoString = `I have ${isEveryVoterRewarded ? 'successfully ' : ''}paid ${isEveryRewardSaved ? 'and saved ' : ''}`;
 
     if (isEveryVoterRewarded) {
       if (isEveryRewardSaved) {
@@ -90,18 +89,18 @@ class Payer {
       }
 
       payoutInfoString += (
-        `of ${paidCount} payouts, ${paidUserRewards.toFixed(4)} ADM plus ` +
+        `of ${paidCount} voter rewards, ${paidUserRewards.toFixed(4)} ADM plus ` +
         `${paymentFees.toFixed(1)} ADM fees in total.`
       );
     } else {
       payoutInfoString += (
-        `only ${paidCount} of ${votersToReward.length} payouts, ` +
+        `only ${paidCount} of ${votersToReward.length} voter rewards, ` +
         `${(paidUserRewards + paymentFees).toFixed(4)} of ${pendingUserRewards.toFixed(4)} ADM.`
       );
     }
 
     if (!isEveryRewardSaved) {
-      payoutInfoString += `\nThere is an issue${!isEveryVoterRewarded ? ' with payouts and database updates' : ' with database updates'}.`;
+      payoutInfoString += `\nThere is an issue${!isEveryVoterRewarded ? ' with reward payouts and database updates' : ' with database updates'}.`;
 
       if (updatedVoters < paidCount) {
         payoutInfoString += ` I've updated only ${updatedVoters} voters.`;
@@ -116,12 +115,12 @@ class Payer {
     payoutInfoString += maintenanceString;
     payoutInfoString += donateString;
 
-    payoutInfoString += `\nThe pool's balance — ${balance.toFixed(4)} ADM.`;
+    payoutInfoString += `\nThe pool balance — ${balance.toFixed(4)} ADM.`;
 
     if (!isEveryVoterRewarded) {
       const timeoutInMin = ((nextRetryNo * RETRY_PAYOUTS_TIMEOUT) / 1000 / 60).toFixed(1);
 
-      payoutInfoString += `\nI will retry the remaining voter payouts in ${timeoutInMin} minutes, retryNo: ${nextRetryNo}.`;
+      payoutInfoString += `\nI will retry the remaining voter payouts in ${timeoutInMin} minutes, retry #${nextRetryNo}.`;
     }
 
     notifier(`Pool ${config.logName}: ${payoutInfoString}`, notifyType);
@@ -166,7 +165,7 @@ class Payer {
           savedTransactions += 1;
         }
       } catch (error) {
-        log.error(`Error while doing payouts for ${voter.address}: ${error}`);
+        log.error(`Error while paying reward to voter ${voter.address}: ${error}`);
       }
     }
 
@@ -186,8 +185,8 @@ class Payer {
 
     const result = { amount };
 
-    log.debug(`Preparing payout for ${address}: pending ${pending.toFixed(8)} ADM, fee ${FEE.toFixed(8)} ADM.`);
-    log.log(`Processing payment of ${amount.toFixed(8)} ADM reward to ${address}…`);
+    log.debug(`Preparing payout for ${address}: Pending ${pending.toFixed(8)} ADM, fee ${FEE} ADM.`);
+    log.debug(`Processing payment of ${amount.toFixed(8)} ADM reward to ${address}…`);
 
     const payment = await adamantApiClient.sendTokens(config.passPhrase, address, amount);
 
@@ -221,14 +220,14 @@ class Payer {
           });
     } catch {
       log.error(
-          `Failed to update rewards for ${address} after successful payout. ` +
-          `Do it manually: ${received.toFixed(8)} ADM received in total, 0 ADM pending.`,
+          `Failed to update rewards record for ${address} after a successful payout. ` +
+          `You can do it manually: ${received.toFixed(8)} ADM received in total, 0 ADM pending.`,
       );
       return;
     }
 
     log.log(
-        `Voter's rewards successfully updated after payout: ${received.toFixed(8)} ADM received in total, ` +
+        `Voter rewards successfully updated after payout: ${received.toFixed(8)} ADM received in total, ` +
         `0 ADM pending for ${address}.`,
     );
     result.isUpdated = true;
@@ -237,15 +236,15 @@ class Payer {
       await mongo.transactionsCollection.insertOne(transaction);
     } catch {
       log.error(
-          `Failed to save transaction ${transaction.transactionId} after successful payout. ` +
-          `Do it manually: ${pending.toFixed(8)} ADM paid to ${address}.`,
+          `Failed to save transaction record ${transaction.transactionId} after a successful payout. ` +
+          `You can do it manually: ${pending.toFixed(8)} ADM paid to ${address}.`,
       );
       return;
     }
 
     log.log(
-        `Successfully saved transaction ${transaction.transactionId} ` +
-        `after payout: ${pending.toFixed(8)} ADM paid to ${address}.`,
+        `Successfully saved transaction record ${transaction.transactionId} ` +
+        `after a successful payout: ${pending.toFixed(8)} ADM paid to ${address}.`,
     );
     result.isTransactionSaved = true;
 
@@ -264,7 +263,7 @@ class Payer {
       const donateADM = (config.donate_percentage * totalForgedADM) / 100;
       const maintenanceADM = totalForgedADM - userRewardsADM - donateADM;
 
-      const payAmount = `ADM (${config.poolsShare.toFixed(2)}%) pool's share to maintenance wallet ${config.maintenancewallet}`;
+      const payAmount = `ADM (${config.poolsShare.toFixed(2)}%) pool share to maintenance wallet ${config.maintenancewallet}`;
       const notifyPayAmount = `${maintenanceADM.toFixed(4)} ${payAmount}`;
       const logPayAmount = `${maintenanceADM.toFixed(8)} ${payAmount}`;
 
@@ -273,7 +272,7 @@ class Payer {
       if (config.maintenancewallet) {
         if (!periodInfo.maintenancePaid) {
           if (maintenanceADM - FEE > 0) {
-            log.log(`${logPayAmount}…`);
+            log.debug(`Processing payment of ${logPayAmount} to the maintenance wallet ${config.maintenancewallet}…`);
 
             const paymentMaintenance = await adamantApiClient.sendTokens(
                 config.passPhrase,
@@ -287,21 +286,21 @@ class Payer {
               log.log(`Successfully paid ${logPayAmount} with Tx ${paymentMaintenance.transactionId}.`);
               maintenanceString = `\nSent ${notifyPayAmount}.`;
             } else {
-              maintenanceString = `\nUnable to send ${notifyPayAmount}, do it manually. ${paymentMaintenance.errorMessage}.`;
+              maintenanceString = `\nUnable to send ${notifyPayAmount}, you can do it manually. ${paymentMaintenance.errorMessage}.`;
             }
           } else {
             maintenanceString = (
-              `\nPool's share ${maintenanceADM.toFixed(4)} ADM ` +
+              `\nPool share ${maintenanceADM.toFixed(4)} ADM ` +
               `(${config.poolsShare.toFixed(2)}%) is lower than the Tx fee.`
             );
           }
         }
       } else {
         if (maintenanceADM > 0) {
-          maintenanceString = `\nMaintenance wallet is not set. Leaving pool's share of ${notifyPayAmount}.`;
+          maintenanceString = `\nMaintenance wallet is not set. Leaving pool share ${notifyPayAmount} in the pool.`;
         } else {
           maintenanceString = (
-            `\nMaintenance wallet is not set; Pool's share ${maintenanceADM.toFixed(4)} ` +
+            `\nMaintenance wallet is not set; Pool share ${maintenanceADM.toFixed(4)} ` +
             `ADM (${config.poolsShare.toFixed(2)}%) is lower than the Tx fee.`
           );
         }
@@ -333,7 +332,7 @@ class Payer {
       let donateString = '';
 
       if (donateADM - FEE > 0) {
-        log.log(`Processing payment of ${logDonationAmount}…`);
+        log.debug(`Processing payment of ${logDonationAmount} to the donation wallet ${config.donatewallet}…`);
 
         const paymentDonate = await adamantApiClient.sendTokens(
             config.passPhrase,
@@ -344,11 +343,11 @@ class Payer {
         if (paymentDonate.success) {
           periodInfo.donatePaid = true;
 
-          log.log(`Successfully paid ${logDonationAmount}.`);
+          log.log(`Successfully paid ${logDonationAmount} with Tx ${paymentDonate.transactionId}.`);
 
           donateString = `\nSent ${notifyDonationAmount}.`;
         } else {
-          donateString = `\nUnable to send ${notifyDonationAmount}, do it manually. ${paymentDonate.errorMessage}.`;
+          donateString = `\nUnable to send ${notifyDonationAmount}, you can do it manually. ${paymentDonate.errorMessage}.`;
         }
       } else {
         donateString = (
@@ -379,12 +378,12 @@ class Payer {
       setTimeout(() => {
         notifier(
             `Pool ${config.logName}: After ${RETRY_PAYOUTS_COUNT + 1} tries, ` +
-            'payouts are still incomplete. Check the log file.',
+            'payouts are still incomplete. Check the log file for details.',
             'error',
         );
       }, 1000);
     } else {
-      log.log(`Retrying payouts attempt ${retryNo} in ${timeout / 1000} seconds.`);
+      log.log(`Retrying rewards payout attempt #${retryNo} in ${timeout / 1000} seconds.`);
 
       setTimeout(this.payOut.bind(this), timeout);
     }
@@ -396,6 +395,7 @@ class Payer {
    */
   async updateVoters() {
     const voters = await mongo.votersCollection.find({}).toArray();
+
     const {
       votersToReward,
       votersBelowMin,
@@ -423,10 +423,10 @@ class Payer {
     const { pendingUserRewards, votersToReward, votersBelowMin, belowMinRewards } = this;
     const { totalForgedADM, userRewardsADM, forgedBlocks } = store.periodInfo;
 
-    let infoString = `Pending ${pendingUserRewards.toFixed(4)} ADM rewards for ${votersToReward.length} voters.`;
+    let infoString = `Pending ${pendingUserRewards.toFixed(4)} ADM rewards to ${votersToReward.length} voters.`;
     infoString += `\n${votersBelowMin.length} voters have less than the minimum ${config.minpayout} ADM; their pending rewards are ${belowMinRewards.toFixed(4)} ADM.`;
-    infoString += `\nThis period the pool forged ${totalForgedADM.toFixed(4)} ADM from ${forgedBlocks} blocks; ${userRewardsADM.toFixed(4)} ADM distributed to users.`;
-    infoString += `\nThe pool's balance — ${balance.toFixed(4)} ADM.`;
+    infoString += `\nThe pool forged ${totalForgedADM.toFixed(4)} ADM from ${forgedBlocks} blocks this period; ${userRewardsADM.toFixed(4)} ADM distributed to voters.`;
+    infoString += `\nThe pool balance — ${balance.toFixed(4)} ADM.`;
 
     return infoString;
   }

--- a/server/src/modules/pay_out.js
+++ b/server/src/modules/pay_out.js
@@ -4,7 +4,7 @@ import {
   RETRY_PAYOUTS_TIMEOUT,
   SAT,
 } from '../defines.js';
-import store from './store.js';
+import store, { normalizePendingReward } from './store.js';
 
 import { adamantApiClient, config, log, notifier } from '../helpers/index.js';
 import mongo from '../repository/mongodb/index.js';
@@ -179,11 +179,14 @@ class Payer {
    * @returns {Promise<{amount: number, isUpdated?: boolean, isTransactionSaved?: boolean}|void>}
    */
   async payVoter(voter) {
-    let { pending, address, received } = voter;
-    const amount = voter.pending - FEE;
+    const { address } = voter;
+    const pending = normalizePendingReward(voter);
+    let received = Number(voter.received) || 0;
+    const amount = pending - FEE;
 
     const result = { amount };
 
+    log.debug(`Preparing payout for ${address}: pending ${pending.toFixed(8)} ADM, fee ${FEE.toFixed(8)} ADM.`);
     log.log(`Processing payment of ${amount.toFixed(8)} ADM reward to ${address}…`);
 
     const payment = await adamantApiClient.sendTokens(config.passPhrase, address, amount);
@@ -404,6 +407,11 @@ class Payer {
     this.votersBelowMin = votersBelowMin;
     this.pendingUserRewards = pendingUserRewards;
     this.belowMinRewards = belowMinRewards;
+
+    log.debug(
+        `Loaded payout candidates: ${votersToReward.length} payable voters, ` +
+        `${votersBelowMin.length} below-minimum voters.`,
+    );
   }
 
   /**
@@ -429,7 +437,7 @@ class Payer {
  * @param {object[]} voters Voter records loaded from storage
  * @returns {{votersToReward: object[], votersBelowMin: object[], pendingUserRewards: number, belowMinRewards: number}}
  */
-function getVotersRewards(voters) {
+export function getVotersRewards(voters) {
   const votersToReward = [];
   const votersBelowMin = [];
 
@@ -437,12 +445,14 @@ function getVotersRewards(voters) {
   let belowMinRewards = 0;
 
   voters.forEach((voter) => {
-    if (voter.pending >= config.minpayout) {
+    const pending = normalizePendingReward(voter);
+
+    if (pending >= config.minpayout) {
       votersToReward.push(voter);
-      pendingUserRewards += voter.pending;
+      pendingUserRewards += pending;
     } else {
       votersBelowMin.push(voter);
-      belowMinRewards += voter.pending;
+      belowMinRewards += pending;
     }
   });
 

--- a/server/src/modules/store.js
+++ b/server/src/modules/store.js
@@ -216,7 +216,7 @@ const store = {
         voter.votesCount = await this.updateVotes(voter.address);
       }
 
-      log.log(`Updated voters: ${this.delegate.voters.length} accounts`);
+      log.log(`Updated voter list: ${this.delegate.voters.length} accounts.`);
       log.debug(`Updated vote counts for ${this.delegate.voters.length} voters.`);
     } else {
       log.warn(`Failed to get voters for ${config.address}. ${getVotersResponse.errorMessage}.`);
@@ -240,7 +240,7 @@ const store = {
 
       this.delegate.balance = +this.delegate.balance;
 
-      log.log(`Updated balance: ${utils.satsToADM(this.delegate.balance)} ADM`);
+      log.log(`Updated delegate balance: ${utils.satsToADM(this.delegate.balance)} ADM.`);
     } else {
       log.warn(`Failed to get account data for ${config.address}. ${getAccountInfoResponse.errorMessage}.`);
     }
@@ -268,10 +268,10 @@ const store = {
       const votesWeightInADM = utils.satsToADM(this.delegate.votesWeight);
 
       log.log(
-          `Updated delegate ${formatDelegateName(this.delegate.username)}: ` +
+          `Updated delegate ${formatDelegateName(this.delegate.username)} details: ` +
           `rank ${this.delegate.rank}, ` +
           `productivity ${this.delegate.productivity}%, ` +
-          `votesWeight ${votesWeightInADM} ADM`,
+          `votesWeight ${votesWeightInADM} ADM.`,
       );
 
       return this.delegate;

--- a/server/src/modules/store.js
+++ b/server/src/modules/store.js
@@ -118,14 +118,14 @@ const store = {
         const totalADM = utils.satsToADM(forged);
 
         log.log(
-            `Updated forged info for delegate ${formatDelegateName(this.delegate.username)}: ` +
+            `Updated forged info for delegate ${config.logName}: ` +
             `total ${totalADM} ADM, ` +
             `block rewards ${rewardsInADM} ADM, ` +
             `fees ${feesInADM} ADM.`,
         );
       } else {
         log.warn(
-            `Failed to get forged info for delegate for ${config.address}. ` +
+            `Failed to get forged info for delegate ${config.address}. ` +
             `${delegateForgedInfoResponse.errorMessage}.`,
         );
       }
@@ -139,10 +139,13 @@ const store = {
         nextRunDateString: nextRunMoment.toISODate(),
       };
 
-      const transactions = await mongo.transactionsCollection.find({}).toArray();
-
-      // Assume previous run is the last saved transaction
-      const lastTransaction = transactions.sort((a, b) => b.timeStamp - a.timeStamp)[0];
+      // Assume the previous run is the most recent saved transaction.
+      // Backed by the { timeStamp: -1 } index, so this reads one document instead of the whole collection.
+      const [lastTransaction] = await mongo.transactionsCollection
+          .find({})
+          .sort({ timeStamp: -1 })
+          .limit(1)
+          .toArray();
 
       if (lastTransaction) {
         const previousRunTimestamp = lastTransaction.timeStamp;
@@ -216,7 +219,7 @@ const store = {
         voter.votesCount = await this.updateVotes(voter.address);
       }
 
-      log.log(`Updated voter list: ${this.delegate.voters.length} accounts.`);
+      log.log(`Updated voter list for delegate ${config.logName}: ${this.delegate.voters.length} accounts.`);
       log.debug(`Updated vote counts for ${this.delegate.voters.length} voters.`);
     } else {
       log.warn(`Failed to get voters for ${config.address}. ${getVotersResponse.errorMessage}.`);
@@ -240,7 +243,7 @@ const store = {
 
       this.delegate.balance = +this.delegate.balance;
 
-      log.log(`Updated delegate balance: ${utils.satsToADM(this.delegate.balance)} ADM.`);
+      log.log(`Updated balance for delegate ${config.logName}: ${utils.satsToADM(this.delegate.balance)} ADM.`);
     } else {
       log.warn(`Failed to get account data for ${config.address}. ${getAccountInfoResponse.errorMessage}.`);
     }
@@ -265,10 +268,15 @@ const store = {
       };
       this.delegate.votesWeight = +this.delegate.votesWeight;
 
+      // The account is confirmed to be a delegate here, so it is safe to identify
+      // it by name everywhere via config.logName (`'name' (address)`).
+      config.poolName = this.delegate.username;
+      config.logName = `${formatDelegateName(this.delegate.username)} (${config.address})`;
+
       const votesWeightInADM = utils.satsToADM(this.delegate.votesWeight);
 
       log.log(
-          `Updated delegate ${formatDelegateName(this.delegate.username)} details: ` +
+          `Updated delegate ${config.logName} details: ` +
           `rank ${this.delegate.rank}, ` +
           `productivity ${this.delegate.productivity}%, ` +
           `votesWeight ${votesWeightInADM} ADM.`,

--- a/server/src/modules/store.js
+++ b/server/src/modules/store.js
@@ -76,6 +76,10 @@ const store = {
     pendingRewardsADM: 0,
   },
 
+  /**
+   * Refreshes delegate, voters, balance, and period stats in parallel.
+   * @returns {Promise<unknown[]>} Resolves once every update settles
+   */
   updateAll() {
     const updates = [
       this.updateDelegate(),
@@ -87,6 +91,10 @@ const store = {
     return Promise.all(updates);
   },
 
+  /**
+   * Updates forged totals, payout period boundaries, and the aggregate pending rewards shown on the dashboard.
+   * @returns {Promise<void>}
+   */
   async updateStats() {
     try {
       const delegateForgedInfoResponse = await adamantApiClient.getDelegateStats(config.publicKey);
@@ -179,6 +187,11 @@ const store = {
     }
   },
 
+  /**
+   * Reads how many delegates a given account currently votes for.
+   * @param {string} address ADAMANT address of the voter
+   * @returns {Promise<number|undefined>} Number of delegates voted for, or undefined when the lookup fails
+   */
   async updateVotes(address) {
     const getVoteDataResponse = await adamantApiClient.getVoteData(address);
 
@@ -189,6 +202,10 @@ const store = {
     }
   },
 
+  /**
+   * Refreshes the delegate's voter list and each voter's vote count.
+   * @returns {Promise<void>}
+   */
   async updateVoters() {
     const getVotersResponse = await adamantApiClient.getVoters(config.publicKey);
 
@@ -206,6 +223,10 @@ const store = {
     }
   },
 
+  /**
+   * Refreshes the delegate account data and current balance in sats.
+   * @returns {Promise<void>}
+   */
   async updateBalance() {
     const getAccountInfoResponse = await adamantApiClient.getAccountInfo({
       publicKey: config.publicKey,
@@ -225,6 +246,10 @@ const store = {
     }
   },
 
+  /**
+   * Refreshes delegate rank, productivity, and total vote weight.
+   * @returns {Promise<object|undefined>} Updated delegate state, or undefined when the lookup fails
+   */
   async updateDelegate() {
     const getDelegateResponse = await adamantApiClient.getDelegate({
       publicKey: config.publicKey,

--- a/server/src/modules/store.js
+++ b/server/src/modules/store.js
@@ -37,6 +37,17 @@ export function normalizeDelegateRank(delegate, fallbackRank = 0) {
   return 0;
 }
 
+/**
+ * Reads a voter's pending rewards as a finite ADM amount.
+ * @param {object} voter Voter database record that may contain numeric or string pending rewards
+ * @returns {number} Pending rewards in ADM, or 0 when the stored value is invalid
+ */
+export function normalizePendingReward(voter) {
+  const pending = Number(voter.pending);
+
+  return Number.isFinite(pending) ? pending : 0;
+}
+
 const store = {
   isDistributingRewards: false,
   periodInfo: {
@@ -161,7 +172,8 @@ const store = {
 
       const voters = await mongo.votersCollection.find({}).toArray();
 
-      this.delegate.pendingRewardsADM = voters.reduce((sum, voter) => sum + voter.pending, 0);
+      this.delegate.pendingRewardsADM = voters.reduce((sum, voter) => sum + normalizePendingReward(voter), 0);
+      log.debug(`Updated pending rewards total: ${this.delegate.pendingRewardsADM.toFixed(8)} ADM.`);
     } catch (error) {
       log.error(`Error while updating forging and period stats: ${error}`);
     }
@@ -188,6 +200,7 @@ const store = {
       }
 
       log.log(`Updated voters: ${this.delegate.voters.length} accounts`);
+      log.debug(`Updated vote counts for ${this.delegate.voters.length} voters.`);
     } else {
       log.warn(`Failed to get voters for ${config.address}. ${getVotersResponse.errorMessage}.`);
     }

--- a/server/src/repository/mongodb/index.js
+++ b/server/src/repository/mongodb/index.js
@@ -8,15 +8,23 @@ const client = new MongoClient(uri);
 await client.connect();
 const db = client.db(dbName);
 
+// Unique indexes keep block parsing and reward accounting idempotent.
 await db.collection('blocks').createIndex({ id: 1 }, { unique: true });
 await db.collection('voters').createIndex({ address: 1 }, { unique: true });
+
+// Range scan over the current payout period in store.updateStats().
+await db.collection('blocks').createIndex({ timestamp: 1 });
+// Latest payout lookup (sort by timeStamp desc, limit 1) in store.updateStats().
+await db.collection('transactions').createIndex({ timeStamp: -1 });
 
 /**
  * MongoDB collections used by the pool.
  *
  * Unique indexes on `blocks.id` and `voters.address` keep block parsing and
  * reward accounting idempotent, so duplicate inserts are rejected rather than
- * double-counted.
+ * double-counted. Secondary indexes on `blocks.timestamp` and
+ * `transactions.timeStamp` back the period range scan and latest-payout lookup
+ * in `store.updateStats()`.
  *
  * @type {{blocksCollection: import('mongodb').Collection, transactionsCollection: import('mongodb').Collection, votersCollection: import('mongodb').Collection}}
  */

--- a/server/src/repository/mongodb/index.js
+++ b/server/src/repository/mongodb/index.js
@@ -11,6 +11,15 @@ const db = client.db(dbName);
 await db.collection('blocks').createIndex({ id: 1 }, { unique: true });
 await db.collection('voters').createIndex({ address: 1 }, { unique: true });
 
+/**
+ * MongoDB collections used by the pool.
+ *
+ * Unique indexes on `blocks.id` and `voters.address` keep block parsing and
+ * reward accounting idempotent, so duplicate inserts are rejected rather than
+ * double-counted.
+ *
+ * @type {{blocksCollection: import('mongodb').Collection, transactionsCollection: import('mongodb').Collection, votersCollection: import('mongodb').Collection}}
+ */
 export default {
     blocksCollection: db.collection('blocks'),
     transactionsCollection: db.collection('transactions'),

--- a/server/tests/helpers/config_validate.test.js
+++ b/server/tests/helpers/config_validate.test.js
@@ -1,0 +1,33 @@
+import validateConfig from '../../src/helpers/config/validate.js';
+
+describe('validateConfig', () => {
+  it('should allow configured values listed in allowedValues', () => {
+    const config = {
+      address: 'U1',
+      log_level: 'debug',
+    };
+    const schema = {
+      log_level: {
+        type: String,
+        allowedValues: ['none', 'error', 'warn', 'info', 'log', 'debug'],
+      },
+    };
+
+    expect(validateConfig(config, schema)).toBeUndefined();
+  });
+
+  it('should reject configured values outside allowedValues', () => {
+    const config = {
+      address: 'U1',
+      log_level: 'trace',
+    };
+    const schema = {
+      log_level: {
+        type: String,
+        allowedValues: ['none', 'error', 'warn', 'info', 'log', 'debug'],
+      },
+    };
+
+    expect(validateConfig(config, schema)).toContain('must be one of: none, error, warn, info, log, debug');
+  });
+});

--- a/server/tests/helpers/log.test.js
+++ b/server/tests/helpers/log.test.js
@@ -1,0 +1,39 @@
+import config from '../../src/helpers/config/reader.js';
+import { jest } from '@jest/globals';
+
+const log = (await import('../../src/helpers/log.js')).default;
+
+describe('log debug level', () => {
+  const originalLogLevel = config.log_level;
+  let consoleSpy;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    config.log_level = originalLogLevel;
+    consoleSpy.mockRestore();
+  });
+
+  it('should hide debug messages below debug verbosity', () => {
+    config.log_level = 'log';
+
+    log.debug('hidden debug message');
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('should write debug messages at debug verbosity', () => {
+    config.log_level = 'debug';
+
+    log.debug('visible debug message');
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+        '\x1b[36m',
+        expect.stringContaining('debug|'),
+        '\x1b[0m',
+        'visible debug message',
+    );
+  });
+});

--- a/server/tests/helpers/mongoMock.js
+++ b/server/tests/helpers/mongoMock.js
@@ -76,6 +76,19 @@ function createCollection() {
 
       Object.assign(document, update.$set ?? {});
 
+      for (const [key, value] of Object.entries(update.$inc ?? {})) {
+        document[key] = (document[key] ?? 0) + value;
+      }
+
+      for (const [key, value] of Object.entries(update.$addToSet ?? {})) {
+        if (!Array.isArray(document[key])) {
+          document[key] = [];
+        }
+        if (!document[key].includes(value)) {
+          document[key].push(value);
+        }
+      }
+
       return { acknowledged: true, matchedCount: 1, modifiedCount: 1 };
     },
   };

--- a/server/tests/helpers/mongoMock.js
+++ b/server/tests/helpers/mongoMock.js
@@ -1,5 +1,46 @@
+function matchesField(actual, condition) {
+  if (condition && typeof condition === 'object' && !Array.isArray(condition)) {
+    return Object.entries(condition).every(([operator, value]) => {
+      switch (operator) {
+        case '$gte': return actual >= value;
+        case '$gt': return actual > value;
+        case '$lte': return actual <= value;
+        case '$lt': return actual < value;
+        case '$ne': return actual !== value;
+        default: return actual === value;
+      }
+    });
+  }
+
+  return actual === condition;
+}
+
 function matchesQuery(document, query = {}) {
-  return Object.entries(query).every(([key, value]) => document[key] === value);
+  return Object.entries(query).every(([key, condition]) => matchesField(document[key], condition));
+}
+
+function createCursor(documents) {
+  let result = documents;
+
+  const cursor = {
+    sort(spec) {
+      const [field, direction] = Object.entries(spec)[0];
+
+      result = [...result].sort((a, b) => (a[field] - b[field]) * direction);
+
+      return cursor;
+    },
+    limit(count) {
+      result = result.slice(0, count);
+
+      return cursor;
+    },
+    async toArray() {
+      return result;
+    },
+  };
+
+  return cursor;
 }
 
 function createCollection() {
@@ -17,9 +58,7 @@ function createCollection() {
     },
 
     find(query = {}) {
-      return {
-        toArray: async () => this.data.filter((document) => matchesQuery(document, query)),
-      };
+      return createCursor(this.data.filter((document) => matchesQuery(document, query)));
     },
 
     async insertOne(document) {

--- a/server/tests/modules/block_parser.test.js
+++ b/server/tests/modules/block_parser.test.js
@@ -60,7 +60,7 @@ describe('blockParser.parse', () => {
 
     await blockParser.parse({ id });
 
-    expect(RewardDistributor).toHaveBeenCalledTimes(1);
+    expect(RewardDistributor).toHaveBeenCalledTimes(0);
     expect(mockDistribute).toHaveBeenCalledTimes(0);
   });
 
@@ -84,5 +84,7 @@ describe('blockParser.parse', () => {
     expect(mockDistribute).toHaveBeenCalledTimes(1);
     expect(savedBlockBeforeParsing).toBeUndefined();
     expect(savedBlockAfterParsing.id).toBe(id);
+    expect(savedBlockAfterParsing.processed).toBe(false);
+    expect(savedBlockAfterParsing.rewardedAddresses).toStrictEqual([]);
   });
 });

--- a/server/tests/modules/pay_out.test.js
+++ b/server/tests/modules/pay_out.test.js
@@ -1,0 +1,140 @@
+import { jest } from '@jest/globals';
+
+import mongoMock from '../helpers/mongoMock.js';
+
+const sendTokens = jest.fn();
+const log = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  log: jest.fn(),
+  debug: jest.fn(),
+};
+const notifier = jest.fn();
+
+jest.unstable_mockModule('../../src/repository/mongodb/index.js', () => ({
+  __esModule: true,
+  default: mongoMock,
+}));
+
+jest.unstable_mockModule('../../src/helpers/index.js', () => ({
+  __esModule: true,
+  adamantApiClient: {
+    sendTokens,
+  },
+  config: {
+    donate_percentage: 0,
+    donatewallet: '',
+    logName: 'test-pool',
+    maintenancewallet: '',
+    minpayout: 0.51,
+    passPhrase: 'test passphrase',
+    poolsShare: 20,
+  },
+  log,
+  notifier,
+}));
+
+jest.unstable_mockModule('../../src/modules/store.js', () => ({
+  __esModule: true,
+  default: {
+    delegate: {
+      balance: 100_000_000_000,
+    },
+    periodInfo: {
+      forgedBlocks: 1,
+      totalForgedADM: 10,
+      userRewardsADM: 8,
+    },
+  },
+  normalizePendingReward(voter) {
+    const pending = Number(voter.pending);
+
+    return Number.isFinite(pending) ? pending : 0;
+  },
+}));
+
+const { default: Payer, getVotersRewards } = await import('../../src/modules/pay_out.js');
+
+describe('getVotersRewards', () => {
+  it('should split voters and sum pending rewards numerically', () => {
+    const result = getVotersRewards([
+      { address: 'U1', pending: '1.25' },
+      { address: 'U2', pending: '0.25' },
+      { address: 'U3', pending: 'invalid' },
+    ]);
+
+    expect(result.votersToReward.map((voter) => voter.address)).toStrictEqual(['U1']);
+    expect(result.votersBelowMin.map((voter) => voter.address)).toStrictEqual(['U2', 'U3']);
+    expect(result.pendingUserRewards).toBe(1.25);
+    expect(result.belowMinRewards).toBe(0.25);
+  });
+});
+
+describe('Payer.payVoter', () => {
+  beforeEach(() => {
+    mongoMock.resetAll();
+    sendTokens.mockReset();
+    Object.values(log).forEach((mock) => mock.mockClear());
+  });
+
+  it('should pay a voter, reset pending rewards, and save the transaction', async () => {
+    sendTokens.mockResolvedValue({
+      success: true,
+      transactionId: 'tx-1',
+    });
+
+    await mongoMock.votersCollection.insertOne({
+      address: 'U1',
+      pending: '1.25',
+      received: '2',
+    });
+
+    const payer = new Payer();
+    const result = await payer.payVoter({
+      address: 'U1',
+      pending: '1.25',
+      received: '2',
+    });
+
+    const voter = await mongoMock.votersCollection.findOne({ address: 'U1' });
+    const transaction = await mongoMock.transactionsCollection.findOne({ transactionId: 'tx-1' });
+
+    expect(sendTokens).toHaveBeenCalledWith('test passphrase', 'U1', 0.75);
+    expect(result).toStrictEqual({
+      amount: 0.75,
+      isUpdated: true,
+      isTransactionSaved: true,
+    });
+    expect(voter.pending).toBe(0);
+    expect(voter.received).toBe(3.25);
+    expect(transaction.payoutcount).toBe(1.25);
+  });
+
+  it('should keep pending rewards unchanged when the API rejects the payout', async () => {
+    sendTokens.mockResolvedValue({
+      success: false,
+      errorMessage: 'network unavailable',
+    });
+
+    await mongoMock.votersCollection.insertOne({
+      address: 'U1',
+      pending: 1.25,
+      received: 2,
+    });
+
+    const payer = new Payer();
+    const result = await payer.payVoter({
+      address: 'U1',
+      pending: 1.25,
+      received: 2,
+    });
+
+    const voter = await mongoMock.votersCollection.findOne({ address: 'U1' });
+
+    expect(result).toBeUndefined();
+    expect(voter.pending).toBe(1.25);
+    expect(voter.received).toBe(2);
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('network unavailable'));
+  });
+});

--- a/server/tests/modules/reward_distributor.test.js
+++ b/server/tests/modules/reward_distributor.test.js
@@ -32,6 +32,11 @@ jest.unstable_mockModule('../../src/modules/store.js', () => ({
       ],
     },
   },
+  normalizePendingReward(voter) {
+    const pending = Number(voter.pending);
+
+    return Number.isFinite(pending) ? pending : 0;
+  },
 }));
 
 const RewardDistributor = (await import('../../src/modules/distribute_rewards.js')).default;
@@ -80,7 +85,59 @@ describe('RewardDistributor.distribute', () => {
       rewardsADM: 0.000008,
       percent: 80,
     });
-    expect(rewardDistributor.isDistributionComplete).toBe(true);
+  });
+
+  it('should add rewards to stored pending values numerically', async () => {
+    const rewardDistributor = new RewardDistributor(mockBlock);
+
+    await mongoMock.blocksCollection.insertOne(mockBlock);
+    await mongoMock.votersCollection.insertOne({
+      address: 'U3247657843720097949',
+      pending: '1.25',
+      received: 0,
+    });
+
+    await rewardDistributor.distributeForVoter({
+      address: 'U3247657843720097949',
+      votesCount: 10,
+      balance: '1000000',
+    });
+
+    const savedVoter = await mongoMock.votersCollection.findOne({ address: 'U3247657843720097949' });
+
+    expect(savedVoter.pending).toBeCloseTo(1.250008);
+  });
+
+  it('should not distribute the same block reward twice to an already recorded voter', async () => {
+    const block = {
+      ...mockBlock,
+      id: 2,
+      processed: false,
+      rewardedAddresses: ['U3247657843720097949'],
+      votersCount: 1,
+      rewardsADM: 0.000008,
+      percent: 80,
+    };
+    const rewardDistributor = new RewardDistributor(block);
+
+    await mongoMock.blocksCollection.insertOne(block);
+
+    await rewardDistributor.distributeForVoter({
+      address: 'U3247657843720097949',
+      votesCount: 10,
+      balance: '1000000',
+    });
+    await rewardDistributor.updateBlockDistribution(
+        rewardDistributor.distributed.votersCount === rewardDistributor.eligibleVotersCount,
+    );
+
+    const savedBlock = await mongoMock.blocksCollection.findOne({ id: 2 });
+    const savedVoter = await mongoMock.votersCollection.findOne({ address: 'U3247657843720097949' });
+
+    expect(savedVoter).toBeUndefined();
+    expect(savedBlock.processed).toBe(true);
+    expect(savedBlock.votersCount).toBe(1);
+    expect(savedBlock.rewardsADM).toBe(0.000008);
   });
 });
 

--- a/server/tests/modules/reward_distributor.test.js
+++ b/server/tests/modules/reward_distributor.test.js
@@ -139,6 +139,51 @@ describe('RewardDistributor.distribute', () => {
     expect(savedBlock.votersCount).toBe(1);
     expect(savedBlock.rewardsADM).toBe(0.000008);
   });
+
+  it('should persist voter progress on the block before the block is marked processed', async () => {
+    const block = { ...mockBlock, id: 3, processed: false, rewardedAddresses: [] };
+    const rewardDistributor = new RewardDistributor(block);
+
+    await mongoMock.blocksCollection.insertOne(block);
+
+    // Only the per-voter step runs; the final updateBlockDistribution() never happens,
+    // simulating a crash right after the voter reward was stored.
+    await rewardDistributor.distributeForVoter({
+      address: 'U3247657843720097949',
+      votesCount: 10,
+      balance: '1000000',
+    });
+
+    const savedBlock = await mongoMock.blocksCollection.findOne({ id: 3 });
+
+    // Progress is already durable, so a retry can skip this voter instead of paying again.
+    expect(savedBlock.rewardedAddresses).toContain('U3247657843720097949');
+    expect(savedBlock.votersCount).toBe(1);
+    expect(savedBlock.rewardsADM).toBeCloseTo(0.000008);
+    expect(savedBlock.processed).toBe(false);
+  });
+
+  it('should not re-pay a voter recorded by incremental progress when the block is retried', async () => {
+    const firstRunBlock = { ...mockBlock, id: 4, processed: false, rewardedAddresses: [] };
+    const voter = { address: 'U3247657843720097949', votesCount: 10, balance: '1000000' };
+
+    await mongoMock.blocksCollection.insertOne(firstRunBlock);
+
+    // First (crashed) run pays the voter and records progress, but never marks the block processed.
+    await new RewardDistributor(firstRunBlock).distributeForVoter(voter);
+
+    const partiallySavedBlock = await mongoMock.blocksCollection.findOne({ id: 4 });
+    const pendingAfterFirstRun = (
+      await mongoMock.votersCollection.findOne({ address: voter.address })
+    ).pending;
+
+    // Retry seeds the distributor from the saved block, exactly as block_parser does.
+    await new RewardDistributor({ ...firstRunBlock, ...partiallySavedBlock }).distributeForVoter(voter);
+
+    const voterAfterRetry = await mongoMock.votersCollection.findOne({ address: voter.address });
+
+    expect(voterAfterRetry.pending).toBe(pendingAfterFirstRun);
+  });
 });
 
 describe('RewardDistributor.findOrCreateVoter', () => {

--- a/server/tests/modules/store.test.js
+++ b/server/tests/modules/store.test.js
@@ -19,6 +19,7 @@ jest.unstable_mockModule('../../src/cron/payout.cron.js', () => ({
 const {
   formatDelegateName,
   normalizeDelegateRank,
+  normalizePendingReward,
 } = await import('../../src/modules/store.js');
 
 describe('store delegate helpers', () => {
@@ -34,5 +35,11 @@ describe('store delegate helpers', () => {
     expect(normalizeDelegateRank({ rank: '17' }, 0)).toBe(17);
     expect(normalizeDelegateRank({ rate: 'invalid', rank: '21' }, 0)).toBe(21);
     expect(normalizeDelegateRank({ rate: 'invalid', rank: null }, 35)).toBe(35);
+  });
+
+  it('should normalize stored pending rewards before summing accounting totals', () => {
+    expect(normalizePendingReward({ pending: '12.5' })).toBe(12.5);
+    expect(normalizePendingReward({ pending: 3 })).toBe(3);
+    expect(normalizePendingReward({ pending: 'invalid' })).toBe(0);
   });
 });


### PR DESCRIPTION
## Description

Reviews and hardens the `server/` backend for issue #9, covering reliability, documentation, the pending-rewards accounting bug (#6), logging, storage performance, and test coverage.

Reward and payout safety:

- normalizes stored pending rewards before reward accumulation, payout grouping, payout execution, and aggregate dashboard totals, so string values from older storage or manual repair cannot corrupt accounting math
- records rewarded voter addresses on block documents and marks blocks `processed` only after every eligible voter is accounted for, fixing the duplicate pending increments behind #6
- carries saved distribution progress into `RewardDistributor` on retries and skips voters already recorded for the same block

Logging:

- adds a `debug` log level with explicit `none < error < warn < info < log < debug` ordering, `config.log_level` gating, schema `allowedValues` validation, and `config.default.jsonc` documentation
- keeps `debug` notifier calls local-only so diagnostics never reach Slack or ADAMANT channels
- unifies delegate identification: logs use `config.logName` (`'name' (address)`) wherever the account is confirmed to be a delegate, and fall back to `config.address` only on failure paths where the account may not be a delegate

Storage performance:

- adds a `blocks.timestamp` index for the per-period range scan and a `transactions.timeStamp` index for the latest-payout lookup in `store.updateStats()`
- replaces the full-collection fetch and in-memory sort for the latest payout with an indexed `sort().limit(1)` read

Documentation and tests:

- adds JSDoc for added or materially changed functions across modules, helpers, cron, API, and storage
- adds focused tests for pending-reward accounting (including the #6 regression), payout behavior, config validation, debug logging, and block parser retry behavior
- extends the Mongo mock with a chainable cursor (`sort`/`limit`) and query operators so tests exercise the real code paths

## Related issue

Closes #9
Closes #6

## External links (optional)

- Issue #9: https://github.com/Adamant-im/pool/issues/9
- Bug #6: https://github.com/Adamant-im/pool/issues/6

## Screenshots or videos (optional)

Not applicable. This PR changes server logic, logging, storage indexes, and tests only.

## Breaking changes

No intentional breaking changes.

- Existing Mongo block documents may gain a new `rewardedAddresses` array as distribution progress is saved. This is additive and preserves the existing aggregate block fields.
- Two secondary indexes are created at startup via idempotent `createIndex` calls. No existing index or document is modified.

## How to test

```sh
npm --prefix server run lint
npm --prefix server test
git diff --check
```

Expected result: all commands pass. Local run: lint clean, 57 tests passing across 8 suites.

## Notes for reviewers

Payout and reward safety:

- pending rewards are treated as ADM numbers even when older storage or manual repair left string values in MongoDB
- `payVoter()` still sends `pending - FEE` and records `received`/`payoutcount` including the fee, preserving the existing payout accounting model
- block retry handling skips voters already recorded for the same block to avoid duplicate pending increments on ordinary retries
- the update is not a multi-document MongoDB transaction. If a process dies between the voter and block updates, manual review may still be needed, but the normal retry path is safer than before

Logging and secret safety:

- `config.logName` is set centrally in `store.updateDelegate()` after the delegate is confirmed, with `config.address` as the early fallback, so no log prints `undefined`
- failure paths such as `Failed to get delegate for <address>` intentionally keep the address only, because the account may not be a delegate
- no passphrases, mnemonics, private keys, notification tokens, API credentials, or local config contents are logged at any level

Storage performance:

- the new indexes target the two recurring `store.updateStats()` queries that previously scanned growing collections every refresh
- point lookups already relied on the existing unique `blocks.id` and `voters.address` indexes; dashboard `find({})` reads return full collections by design and are intentionally left unindexed

## Checklist

- [x] Code is formatted
- [x] Tests added/updated (if needed)
- [x] Documentation updated (if needed)
- [x] Changes tested in all relevant environments
