### PR TITLE
Feat: Encrypt pool passphrase with operator password, add adm-pool CLI and /api/health

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This repository is the maintained successor of the older [`adamant-pool`](https:
 - MongoDB-backed block, voter, and transaction history
 - Public dashboard for pool status, voter rewards, and transactions
 - ADAMANT and Slack notifications for operators
+- Optional operator-password-encrypted passphrase with an `adm-pool` control CLI
+- `GET /api/health` endpoint for external monitoring (e.g. Zabbix)
 - Decentralized ADAMANT node access with node failover through `adamant-api`
 - Migration helpers for older LowDB-based pool data
 
@@ -79,6 +81,51 @@ For production, use a process manager such as [`pm2`](https://pm2.keymetrics.io/
 ```sh
 pm2 start ./scripts/start.sh --name adamantpool
 ```
+
+## Securing the passphrase
+
+The `passPhrase` accepts two forms:
+
+- A **plain passphrase** — simplest, but stored in clear text in the config (kept for compatibility, not recommended).
+- An **operator-encrypted passphrase** — the passphrase is encrypted with an operator password and decrypted only in memory at runtime. A leaked config no longer exposes the pool's forging key.
+
+The `adm-pool` control CLI manages encryption and the runtime lock state:
+
+```sh
+npm run adm-pool encrypt   # prompts for the passphrase and an operator password, prints the encrypted value
+npm run adm-pool unlock    # prompts for the operator password and unlocks a running pool
+npm run adm-pool lock      # clears the decrypted passphrase from the running pool's memory
+npm run adm-pool status    # shows the running pool's status
+```
+
+Workflow:
+
+1. Run `npm run adm-pool encrypt` and paste the resulting `admpool-enc-v1....` string into `config.jsonc` as `passPhrase`.
+2. Start the pool. With an encrypted passphrase it boots **LOCKED**: block sync, the web dashboard, and the public API all work, but **payouts and ADM notifications are paused** until you unlock it.
+   - In a **terminal** (`npm start`), the pool prompts for the operator password on startup.
+   - Under **pm2 / systemd** (no terminal), the pool keeps running locked and waits — unlock it from another shell with `npm run adm-pool unlock`.
+3. A payout that falls due while the pool is locked is **deferred**, not lost: pending rewards remain in the database and are processed as soon as you unlock.
+
+The CLI talks to the running pool over a local Unix socket (owner-only `0600` permissions). Override its path with the `controlSocket` config value when running several pools on one host.
+
+## Monitoring
+
+`GET /api/health` returns a secret-free JSON snapshot for external monitoring such as Zabbix:
+
+```jsonc
+{
+  "status": "ok", // ok | degraded (locked) | starting
+  "version": "3.1.0",
+  "uptime": 12345,
+  "address": "U1234...",
+  "payouts": "unlocked", // unlocked | locked
+  "passphrase": "encrypted",
+  "node": { "ready": true, "rank": 12, "productivity": 99.5 },
+  "nextPayoutTimestamp": 1750086400000
+}
+```
+
+The endpoint always responds with HTTP `200` while the web server is up; a locked pool is intentional, not down, so it is reported as `"status": "degraded"` / `"payouts": "locked"` rather than a `5xx`. Alert on `.status != "ok"` or `.payouts == "locked"`.
 
 ## Migrations
 

--- a/config.default.jsonc
+++ b/config.default.jsonc
@@ -77,10 +77,17 @@
   /** Whether to include the delegate's own vote in reward distribution **/
   "considerownvote": false,
 
-  /** ADAMANT address for monitoring notifications **/
+  /**
+    ADAMANT address for monitoring notifications.
+    Note: sending an ADAMANT message is signed with the pool passphrase, so while
+    the pool is LOCKED (encrypted passphrase not yet unlocked) ADM notifications
+    are paused — including the "payouts are locked" alert itself. If you use an
+    encrypted passphrase, also configure `slack` below (it does not need the
+    passphrase) so you still receive lock alerts.
+  **/
   "adamant_notify": "",
 
-  /** Slack key for monitoring notifications **/
+  /** Slack key for monitoring notifications (works even while the pool is locked) **/
   "slack": "",
 
   /**

--- a/config.default.jsonc
+++ b/config.default.jsonc
@@ -14,8 +14,29 @@
   /**
     The pool's secret phrase. The pool's ADM address/account will correspond to this passPhrase.
     The account should be a delegate of the ADAMANT blockchain.
+
+    Two accepted forms:
+      1. A plain passphrase (not recommended; kept for compatibility).
+      2. An operator-encrypted passphrase (recommended). Generate it with:
+           npm run adm-pool encrypt
+         and paste the resulting "admpool-enc-v1...." string here.
+
+    With an encrypted passphrase the pool boots LOCKED: block sync, the web UI,
+    and the public API all work, but payouts and ADM notifications are paused
+    until you unlock it:
+      - In a terminal, the pool prompts for the operator password on start.
+      - Under pm2/systemd (no terminal), the pool keeps running LOCKED; unlock it with:
+           npm run adm-pool unlock
+    Other commands: `adm-pool status`, `adm-pool lock`.
   **/
   "passPhrase": "",
+
+  /**
+    Path to the local control socket used by the `adm-pool` CLI to unlock/lock/
+    inspect the running pool. Leave empty to use a default derived from the port
+    (in the system temp directory).
+  **/
+  "controlSocket": "",
 
   /** Percentage of rewards to distribute to voters **/
   "reward_percentage": 80,

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "3.1.0",
   "description": "ADAMANT delegate forging pool with automated voter rewards, payouts, and dashboard",
   "main": "server/src/app.js",
+  "bin": {
+    "adm-pool": "server/bin/adm-pool.js"
+  },
   "scripts": {
     "start": "node .",
     "adm-pool": "node server/bin/adm-pool.js",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "server/src/app.js",
   "scripts": {
     "start": "node .",
+    "adm-pool": "node server/bin/adm-pool.js",
     "prepare": "husky",
     "install:all": "npm install --ignore-scripts && npm --prefix ./server install --ignore-scripts && npm --prefix ./web install --ignore-scripts && npm --prefix ./scripts/migrate-lowdb-mongodb install --ignore-scripts",
     "test": "npm --prefix ./server run test",

--- a/server/bin/adm-pool.js
+++ b/server/bin/adm-pool.js
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+import net from 'node:net';
+
+import { createHiddenPrompter } from '../src/helpers/prompt.js';
+import { encrypt } from '../src/helpers/crypto/passphrase.js';
+
+// Keep config-loading side effects quiet so command output stays clean.
+process.env.ADM_POOL_CLI = '1';
+
+const [, , command] = process.argv;
+
+const prompter = createHiddenPrompter();
+
+/**
+ * Prints CLI usage.
+ * @returns {void}
+ */
+function printUsage() {
+  process.stdout.write([
+    'adm-pool — ADAMANT pool control CLI',
+    '',
+    'Usage:',
+    '  adm-pool encrypt   Encrypt a passphrase with an operator password (prints the config value)',
+    '  adm-pool unlock    Unlock a running pool (prompts for the operator password)',
+    '  adm-pool lock      Re-lock a running pool (clears the decrypted passphrase from memory)',
+    '  adm-pool status    Show the running pool status',
+    '',
+  ].join('\n'));
+}
+
+/**
+ * Encrypts a passphrase entered interactively and prints the config value.
+ * Runs standalone — it needs no running pool and no existing config.
+ * @returns {Promise<void>}
+ */
+async function cmdEncrypt() {
+  const passphrase = (await prompter.ask('Passphrase: ')).trim();
+
+  if (!passphrase) {
+    process.stderr.write('Passphrase cannot be empty.\n');
+    process.exit(1);
+  }
+
+  const password = await prompter.ask('Operator password: ');
+  const confirm = await prompter.ask('Confirm operator password: ');
+
+  if (password !== confirm) {
+    process.stderr.write('Operator passwords do not match.\n');
+    process.exit(1);
+  }
+
+  let blob;
+
+  try {
+    blob = encrypt(passphrase, password);
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  }
+
+  process.stdout.write('\nEncrypted passphrase — set it as "passPhrase" in your pool config:\n\n');
+  process.stdout.write(`${blob}\n`);
+}
+
+/**
+ * Sends a single newline-delimited JSON command to the pool control socket.
+ * @param {string} socketPath Control socket path
+ * @param {object} payload Command payload
+ * @returns {Promise<object>} Parsed response
+ */
+function sendCommand(socketPath, payload) {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(socketPath);
+    let buffer = '';
+
+    socket.on('connect', () => socket.write(`${JSON.stringify(payload)}\n`));
+
+    socket.on('data', (chunk) => {
+      buffer += chunk.toString('utf8');
+
+      const newlineIndex = buffer.indexOf('\n');
+
+      if (newlineIndex !== -1) {
+        socket.end();
+
+        try {
+          resolve(JSON.parse(buffer.slice(0, newlineIndex)));
+        } catch (error) {
+          reject(error);
+        }
+      }
+    });
+
+    socket.on('error', (error) => reject(error));
+  });
+}
+
+/**
+ * Resolves the control socket path from the loaded pool config.
+ * @returns {Promise<string>} Control socket path
+ */
+async function getSocketPath() {
+  const { default: config } = await import('../src/helpers/config/reader.js');
+  const { resolveControlSocketPath } = await import('../src/helpers/control/socketPath.js');
+
+  return resolveControlSocketPath(config);
+}
+
+/**
+ * Runs a control command against a running pool, prompting for the password when needed.
+ * @param {'unlock'|'lock'|'status'} cmd Control command
+ * @param {{needsPassword?: boolean}} [options] Command options
+ * @returns {Promise<void>}
+ */
+async function cmdSocket(cmd, { needsPassword = false } = {}) {
+  const socketPath = await getSocketPath();
+
+  const payload = { cmd };
+
+  if (needsPassword) {
+    payload.password = await prompter.ask('Operator password: ');
+  }
+
+  let response;
+
+  try {
+    response = await sendCommand(socketPath, payload);
+  } catch (error) {
+    if (error.code === 'ENOENT' || error.code === 'ECONNREFUSED') {
+      process.stderr.write(`Pool is not running or its control socket was not found at ${socketPath}.\n`);
+    } else {
+      process.stderr.write(`Control request failed: ${error.message}\n`);
+    }
+
+    process.exit(1);
+  }
+
+  if (!response.ok) {
+    process.stderr.write(`${response.error}\n`);
+    process.exit(1);
+  }
+
+  if (cmd === 'status') {
+    printStatus(response.health);
+  } else {
+    process.stdout.write(`${response.message}\n`);
+  }
+}
+
+/**
+ * Prints a pool health snapshot in a human-readable form.
+ * @param {object} health Health snapshot from the pool
+ * @returns {void}
+ */
+function printStatus(health) {
+  const lines = [
+    `Pool:        ${health.delegate ? `${health.delegate} (${health.address})` : health.address}`,
+    `Status:      ${health.status}`,
+    `Payouts:     ${health.payouts}`,
+    `Passphrase:  ${health.passphrase}`,
+    `Node ready:  ${health.node.ready}`,
+    `Version:     ${health.version}`,
+    `Uptime:      ${health.uptime}s`,
+  ];
+
+  if (health.nextPayoutTimestamp) {
+    lines.push(`Next payout: ${new Date(health.nextPayoutTimestamp).toISOString()}`);
+  }
+
+  process.stdout.write(`${lines.join('\n')}\n`);
+}
+
+/**
+ * CLI entry point.
+ * @returns {Promise<void>}
+ */
+async function main() {
+  switch (command) {
+    case 'encrypt':
+      return cmdEncrypt();
+    case 'unlock':
+      return cmdSocket('unlock', { needsPassword: true });
+    case 'lock':
+      return cmdSocket('lock');
+    case 'status':
+      return cmdSocket('status');
+    default:
+      printUsage();
+      process.exit(command ? 1 : 0);
+  }
+}
+
+await main();

--- a/server/bin/adm-pool.js
+++ b/server/bin/adm-pool.js
@@ -34,15 +34,15 @@ function printUsage() {
  * @returns {Promise<void>}
  */
 async function cmdEncrypt() {
-  const passphrase = (await prompter.ask('Passphrase: ')).trim();
+  const passphrase = (await prompter.ask('Enter the pool passphrase to encrypt: ')).trim();
 
   if (!passphrase) {
     process.stderr.write('Passphrase cannot be empty.\n');
     process.exit(1);
   }
 
-  const password = await prompter.ask('Operator password: ');
-  const confirm = await prompter.ask('Confirm operator password: ');
+  const password = await prompter.ask('Enter an operator password: ');
+  const confirm = await prompter.ask('Confirm the operator password: ');
 
   if (password !== confirm) {
     process.stderr.write('Operator passwords do not match.\n');
@@ -107,6 +107,41 @@ async function getSocketPath() {
 }
 
 /**
+ * Reports a control-connection error and exits. A missing socket or refused
+ * connection means the pool is not running.
+ * @param {NodeJS.ErrnoException} error Connection error
+ * @param {string} socketPath Control socket path
+ * @returns {never}
+ */
+function reportConnectionError(error, socketPath) {
+  if (error.code === 'ENOENT' || error.code === 'ECONNREFUSED') {
+    process.stderr.write(`Pool is not running or its control socket was not found at ${socketPath}.\n`);
+  } else {
+    process.stderr.write(`Control request failed: ${error.message}\n`);
+  }
+
+  process.exit(1);
+}
+
+/**
+ * Verifies the pool is running by connecting to its control socket.
+ * @param {string} socketPath Control socket path
+ * @returns {Promise<void>} Resolves when the socket accepts a connection
+ */
+function ensureReachable(socketPath) {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(socketPath);
+
+    socket.on('connect', () => {
+      socket.end();
+      resolve();
+    });
+
+    socket.on('error', (error) => reject(error));
+  });
+}
+
+/**
  * Runs a control command against a running pool, prompting for the password when needed.
  * @param {'unlock'|'lock'|'status'} cmd Control command
  * @param {{needsPassword?: boolean}} [options] Command options
@@ -115,10 +150,20 @@ async function getSocketPath() {
 async function cmdSocket(cmd, { needsPassword = false } = {}) {
   const socketPath = await getSocketPath();
 
+  // Check the pool is up before prompting, so a stopped pool is reported
+  // immediately rather than after the operator has typed the password.
+  if (needsPassword) {
+    try {
+      await ensureReachable(socketPath);
+    } catch (error) {
+      reportConnectionError(error, socketPath);
+    }
+  }
+
   const payload = { cmd };
 
   if (needsPassword) {
-    payload.password = await prompter.ask('Operator password: ');
+    payload.password = await prompter.ask('Enter the operator password: ');
   }
 
   let response;
@@ -126,13 +171,7 @@ async function cmdSocket(cmd, { needsPassword = false } = {}) {
   try {
     response = await sendCommand(socketPath, payload);
   } catch (error) {
-    if (error.code === 'ENOENT' || error.code === 'ECONNREFUSED') {
-      process.stderr.write(`Pool is not running or its control socket was not found at ${socketPath}.\n`);
-    } else {
-      process.stderr.write(`Control request failed: ${error.message}\n`);
-    }
-
-    process.exit(1);
+    reportConnectionError(error, socketPath);
   }
 
   if (!response.ok) {

--- a/server/package.json
+++ b/server/package.json
@@ -5,8 +5,12 @@
   "description": "Backend runtime for ADAMANT Forging Pool rewards, payouts, storage, notifications, and HTTP API",
   "main": "src/app.js",
   "type": "module",
+  "bin": {
+    "adm-pool": "bin/adm-pool.js"
+  },
   "scripts": {
     "start": "node src/app.js",
+    "adm-pool": "node bin/adm-pool.js",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --silent --forceExit"

--- a/server/src/api/control.js
+++ b/server/src/api/control.js
@@ -30,7 +30,7 @@ function handleCommand(message) {
       try {
         const { address } = secret.unlock(password);
 
-        log.log(`Pool ${address} unlocked via control socket. Payouts and ADM notifications enabled.`);
+        log.info(`Pool ${address} unlocked via control socket. Payouts and ADM notifications enabled.`);
 
         return { ok: true, message: `Pool unlocked for ${address}.`, health: buildHealth() };
       } catch (error) {

--- a/server/src/api/control.js
+++ b/server/src/api/control.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import net from 'node:net';
+import path from 'node:path';
 
 import { buildHealth } from '../modules/health.js';
 import config from '../helpers/config/reader.js';
@@ -58,12 +59,22 @@ function handleCommand(message) {
 /**
  * Starts the local control socket that backs `adm-pool unlock`, `lock`, and `status`.
  *
- * Requests and responses are newline-delimited JSON. A stale socket file from a
- * previous run is removed first, and the socket is chmod'd to `0600`.
+ * Requests and responses are newline-delimited JSON. The default socket lives in
+ * a private per-user directory; a stale socket file is removed first, and the
+ * socket is chmod'd to `0600`.
  * @returns {{server: import('node:net').Server, socketPath: string}} The control server and its socket path
+ * @throws {Error} When the default runtime directory cannot be created or protected
  */
 export function startControlServer() {
   const socketPath = resolveControlSocketPath(config);
+
+  // For the default path, place the socket in a private per-user runtime
+  // directory and fail closed if it cannot be protected, so a local attacker
+  // cannot pre-create the predictable socket path or read the socket. A custom
+  // `controlSocket` is trusted to the operator's chosen location.
+  if (!config.controlSocket) {
+    prepareRuntimeDir(path.dirname(socketPath));
+  }
 
   try {
     if (fs.existsSync(socketPath)) {
@@ -113,7 +124,18 @@ export function startControlServer() {
     try {
       fs.chmodSync(socketPath, 0o600);
     } catch (error) {
-      log.warn(`Failed to set permissions on control socket ${socketPath}: ${error.message}.`);
+      // Fail closed: an unprotected unlock socket is worse than no socket.
+      log.error(`Failed to protect control socket ${socketPath}: ${error.message}. Shutting it down.`);
+
+      server.close();
+
+      try {
+        fs.unlinkSync(socketPath);
+      } catch {
+        // Nothing to clean up.
+      }
+
+      return;
     }
 
     log.log(`Pool control socket listening at ${socketPath}.`);
@@ -130,4 +152,25 @@ export function startControlServer() {
   process.once('exit', cleanup);
 
   return { server, socketPath };
+}
+
+/**
+ * Creates the per-user runtime directory for the default control socket and
+ * verifies it is owner-only. Fails closed when the directory exists but is owned
+ * by another user, so an attacker cannot plant a writable directory.
+ * @param {string} dir Runtime directory path
+ * @returns {void}
+ * @throws {Error} When the directory is owned by another user
+ */
+function prepareRuntimeDir(dir) {
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+
+  const stats = fs.statSync(dir);
+
+  if (typeof process.getuid === 'function' && stats.uid !== process.getuid()) {
+    throw new Error(`Control socket directory ${dir} is not owned by the current user.`);
+  }
+
+  // Enforce owner-only access even if the directory already existed with looser permissions.
+  fs.chmodSync(dir, 0o700);
 }

--- a/server/src/api/control.js
+++ b/server/src/api/control.js
@@ -1,0 +1,133 @@
+import fs from 'node:fs';
+import net from 'node:net';
+
+import { buildHealth } from '../modules/health.js';
+import config from '../helpers/config/reader.js';
+import log from '../helpers/log.js';
+import { resolveControlSocketPath } from '../helpers/control/socketPath.js';
+import secret from '../modules/secret.js';
+
+/**
+ * Handles a single control command from the `adm-pool` CLI.
+ *
+ * The control channel is a local Unix domain socket with owner-only (`0600`)
+ * permissions; the operator password is only ever read here, never logged.
+ * @param {{cmd: string, password?: string}} message Parsed control request
+ * @returns {object} JSON-serializable response
+ */
+function handleCommand(message) {
+  const { cmd, password } = message;
+
+  switch (cmd) {
+    case 'status':
+      return { ok: true, health: buildHealth() };
+
+    case 'unlock': {
+      if (!password) {
+        return { ok: false, error: 'Operator password is required.' };
+      }
+
+      try {
+        const { address } = secret.unlock(password);
+
+        log.log(`Pool ${address} unlocked via control socket. Payouts and ADM notifications enabled.`);
+
+        return { ok: true, message: `Pool unlocked for ${address}.`, health: buildHealth() };
+      } catch (error) {
+        return { ok: false, error: error.message };
+      }
+    }
+
+    case 'lock': {
+      try {
+        secret.lock();
+
+        log.log('Pool locked via control socket. Decrypted passphrase cleared from memory.');
+
+        return { ok: true, message: 'Pool locked. Decrypted passphrase cleared from memory.', health: buildHealth() };
+      } catch (error) {
+        return { ok: false, error: error.message };
+      }
+    }
+
+    default:
+      return { ok: false, error: `Unknown command: ${cmd}` };
+  }
+}
+
+/**
+ * Starts the local control socket that backs `adm-pool unlock`, `lock`, and `status`.
+ *
+ * Requests and responses are newline-delimited JSON. A stale socket file from a
+ * previous run is removed first, and the socket is chmod'd to `0600`.
+ * @returns {{server: import('node:net').Server, socketPath: string}} The control server and its socket path
+ */
+export function startControlServer() {
+  const socketPath = resolveControlSocketPath(config);
+
+  try {
+    if (fs.existsSync(socketPath)) {
+      fs.unlinkSync(socketPath);
+    }
+  } catch (error) {
+    log.warn(`Failed to remove stale control socket ${socketPath}: ${error.message}.`);
+  }
+
+  const server = net.createServer((socket) => {
+    let buffer = '';
+
+    socket.on('data', (chunk) => {
+      buffer += chunk.toString('utf8');
+
+      let newlineIndex;
+
+      while ((newlineIndex = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, newlineIndex).trim();
+        buffer = buffer.slice(newlineIndex + 1);
+
+        if (!line) {
+          continue;
+        }
+
+        let response;
+
+        try {
+          response = handleCommand(JSON.parse(line));
+        } catch {
+          response = { ok: false, error: 'Malformed control request.' };
+        }
+
+        socket.write(`${JSON.stringify(response)}\n`);
+      }
+    });
+
+    // The CLI hangs up as soon as it has the response; ignore the reset.
+    socket.on('error', () => {});
+  });
+
+  server.on('error', (error) => {
+    log.error(`Pool control socket error: ${error.message}.`);
+  });
+
+  server.listen(socketPath, () => {
+    try {
+      fs.chmodSync(socketPath, 0o600);
+    } catch (error) {
+      log.warn(`Failed to set permissions on control socket ${socketPath}: ${error.message}.`);
+    }
+
+    log.log(`Pool control socket listening at ${socketPath}.`);
+  });
+
+  const cleanup = () => {
+    try {
+      fs.unlinkSync(socketPath);
+    } catch {
+      // Socket already gone; nothing to clean up.
+    }
+  };
+
+  process.once('exit', cleanup);
+
+  return { server, socketPath };
+}

--- a/server/src/api/index.js
+++ b/server/src/api/index.js
@@ -3,6 +3,7 @@ import cors from 'cors';
 import express from 'express';
 import { fileURLToPath } from 'url';
 
+import { buildHealth } from '../modules/health.js';
 import config from '../helpers/config/reader.js';
 import mongo from '../repository/mongodb/index.js';
 import store from '../modules/store.js';
@@ -30,6 +31,13 @@ app.use(/\.js/, (req, res, next) => {
 app.use('/', express.static(publicDir));
 
 app.get('/', (req, res) => res.sendFile(join(publicDir, 'index.html')));
+
+// Machine-readable health snapshot for external monitoring (e.g. Zabbix).
+// Always HTTP 200 while the web server is up; the operational state lives in
+// the `status` field (`ok` | `degraded` | `starting`) and `payouts`
+// (`unlocked` | `locked`). A locked pool is intentional, not "down", so it is
+// not signalled with a 5xx. Exposes no secrets and accepts no input.
+app.get('/api/health', (req, res) => res.send(buildHealth()));
 
 // Returns all recorded payout transactions.
 app.get('/api/transactions', async (req, res) => {

--- a/server/src/api/index.js
+++ b/server/src/api/index.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url';
 import { buildHealth } from '../modules/health.js';
 import config from '../helpers/config/reader.js';
 import mongo from '../repository/mongodb/index.js';
+import secret from '../modules/secret.js';
 import store from '../modules/store.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -62,6 +63,8 @@ app.get('/api/config', async (req, res) => res.send({
   reward_percentage: config.reward_percentage,
   donate_percentage: config.donate_percentage,
   minpayout: config.minpayout,
+  // True while an encrypted passphrase has not been unlocked, so payouts are paused.
+  locked: secret.status().locked,
   payoutperiod: config.payoutperiod,
   payoutperiodForged: store.periodInfo.totalForgedADM,
   payoutperiodRewards: store.delegate.pendingRewardsADM,

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -27,6 +27,13 @@ server.listen(config.port, () => (
 // Local control channel backing `adm-pool unlock`, `lock`, and `status`.
 const { socketPath } = startControlServer();
 
+if (secret.status().mode === 'plain') {
+  log.warn(
+      `Pool ${config.address} is using a PLAIN passphrase stored in the config file. ` +
+      'For better security, encrypt it with `adm-pool encrypt` and unlock with `adm-pool unlock`.',
+  );
+}
+
 // When the pool is unlocked, process any payout that fell due during the lock.
 secret.on('unlock', () => {
   payoutCron.runDeferred().catch((error) => (

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -5,7 +5,11 @@ import { adamantApiClient, config, log, notifier } from './helpers/index.js';
 import payoutCron from './cron/payout.cron.js';
 
 import blocksChecker from './modules/blocks_checker.js';
+import { promptHidden } from './helpers/prompt.js';
+import secret from './modules/secret.js';
 import server from './api/index.js';
+import { setNodeReady } from './modules/health.js';
+import { startControlServer } from './api/control.js';
 import store from './modules/store.js';
 
 log.start();
@@ -20,8 +24,20 @@ server.listen(config.port, () => (
   log.log(`Pool ${config.address} successfully started the web server on port ${config.port}.`)
 ));
 
+// Local control channel backing `adm-pool unlock`, `lock`, and `status`.
+const { socketPath } = startControlServer();
+
+// When the pool is unlocked, process any payout that fell due during the lock.
+secret.on('unlock', () => {
+  payoutCron.runDeferred().catch((error) => (
+    log.error(`Failed to process deferred payouts after unlock: ${error}`)
+  ));
+});
+
 // Wait for first API health check
 adamantApiClient.onReady(async () => {
+  setNodeReady(true);
+
   await initDelegate();
 
   await blocksChecker();
@@ -29,6 +45,47 @@ adamantApiClient.onReady(async () => {
     await blocksChecker();
   }, UPDATE_BLOCKS_INTERVAL);
 });
+
+await maybeUnlockInteractively();
+
+/**
+ * Resolves the locked-passphrase state at startup. In a terminal the operator is
+ * prompted for the password; under a service manager (pm2/systemd, no TTY) the
+ * pool keeps running LOCKED and waits for `adm-pool unlock` over the control socket.
+ * @returns {Promise<void>}
+ */
+async function maybeUnlockInteractively() {
+  if (secret.status().mode !== 'encrypted' || secret.isUnlocked()) {
+    return;
+  }
+
+  if (!process.stdin.isTTY) {
+    log.warn(
+        `Pool ${config.address} started LOCKED — the passphrase is encrypted and no terminal is attached. ` +
+        `Payouts and ADM notifications are paused. Run \`adm-pool unlock\` (control socket: ${socketPath}).`,
+    );
+
+    return;
+  }
+
+  log.warn('Pool passphrase is encrypted. Enter the operator password to unlock payouts, or press Enter to start LOCKED.');
+
+  const password = await promptHidden('Operator password: ');
+
+  if (!password) {
+    log.warn('No password entered. Pool starting LOCKED. Run `adm-pool unlock` to enable payouts.');
+
+    return;
+  }
+
+  try {
+    secret.unlock(password);
+
+    log.log('Pool unlocked. Payouts and ADM notifications enabled.');
+  } catch (error) {
+    log.error(`Unlock failed: ${error.message}. Pool starting LOCKED. Run \`adm-pool unlock\` to retry.`);
+  }
+}
 
 /**
  * Loads delegate data before starting block checks and public status notifications.

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,6 +1,6 @@
 import * as process from 'node:process';
 
-import { EXIT_CODE_ERROR, UPDATE_BLOCKS_INTERVAL } from './defines.js';
+import { EXIT_CODE_ERROR, UNLOCK_PROMPT_DELAY, UPDATE_BLOCKS_INTERVAL } from './defines.js';
 import { adamantApiClient, config, log, notifier } from './helpers/index.js';
 import payoutCron from './cron/payout.cron.js';
 
@@ -88,6 +88,10 @@ async function maybeUnlockInteractively() {
 
     return;
   }
+
+  // Give the burst of startup logs a moment to flush so the prompt is the last
+  // line on screen instead of being buried in concurrent log output.
+  await new Promise((resolve) => setTimeout(resolve, UNLOCK_PROMPT_DELAY));
 
   log.warn('Pool passphrase is encrypted. Enter the operator password to unlock payouts, or press Enter to start LOCKED.');
 

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -25,7 +25,14 @@ server.listen(config.port, () => (
 ));
 
 // Local control channel backing `adm-pool unlock`, `lock`, and `status`.
-const { socketPath } = startControlServer();
+let socketPath;
+
+try {
+  ({ socketPath } = startControlServer());
+} catch (error) {
+  log.error(`Cannot start the control socket securely: ${error.message} Cannot start Pool.`);
+  process.exit(EXIT_CODE_ERROR);
+}
 
 if (secret.status().mode === 'plain') {
   log.warn(

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -41,9 +41,19 @@ secret.on('unlock', () => {
   ));
 });
 
+// Resolves once the startup unlock prompt has been answered (or skipped). Delegate
+// startup waits on this so it cannot exit the process while the operator is still
+// typing the password at the interactive prompt.
+let markUnlockSettled;
+const unlockSettled = new Promise((resolve) => {
+  markUnlockSettled = resolve;
+});
+
 // Wait for first API health check
 adamantApiClient.onReady(async () => {
   setNodeReady(true);
+
+  await unlockSettled;
 
   await initDelegate();
 
@@ -53,7 +63,11 @@ adamantApiClient.onReady(async () => {
   }, UPDATE_BLOCKS_INTERVAL);
 });
 
-await maybeUnlockInteractively();
+try {
+  await maybeUnlockInteractively();
+} finally {
+  markUnlockSettled();
+}
 
 /**
  * Resolves the locked-passphrase state at startup. In a terminal the operator is
@@ -77,7 +91,7 @@ async function maybeUnlockInteractively() {
 
   log.warn('Pool passphrase is encrypted. Enter the operator password to unlock payouts, or press Enter to start LOCKED.');
 
-  const password = await promptHidden('Operator password: ');
+  const password = await promptHidden('Enter the operator password: ');
 
   if (!password) {
     log.warn('No password entered. Pool starting LOCKED. Run `adm-pool unlock` to enable payouts.');

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -108,7 +108,7 @@ async function maybeUnlockInteractively() {
 
     log.log('Pool unlocked. Payouts and ADM notifications enabled.');
   } catch (error) {
-    log.error(`Unlock failed: ${error.message}. Pool starting LOCKED. Run \`adm-pool unlock\` to retry.`);
+    log.error(`Unlock failed: ${error.message} Pool starting LOCKED. Run \`adm-pool unlock\` to retry.`);
   }
 }
 

--- a/server/src/cron/payout.cron.js
+++ b/server/src/cron/payout.cron.js
@@ -2,6 +2,7 @@ import { CronJob } from 'cron';
 import Payer from '../modules/pay_out.js';
 import config from '../helpers/config/reader.js';
 import log from '../helpers/log.js';
+import secret from '../modules/secret.js';
 
 const payer = new Payer();
 
@@ -18,6 +19,9 @@ const DAYS_OF_WEEK = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
 export default {
   cronJob: {},
+  // Set when a scheduled payout fires while the pool is locked, so the deferred
+  // run can be processed on `adm-pool unlock` (see runDeferred).
+  deferredPayout: false,
   /**
    * Starts the payout cron job for the configured payout period.
    * @param {string} payoutPeriod Payout period: a day name (e.g. `Mon`) or interval key (`1h`, `1d`, `5d`, `10d`, `15d`, `30d`)
@@ -38,7 +42,7 @@ export default {
 
       this.cronJob = CronJob.from({
         cronTime,
-        onTick: payer.payOut.bind(payer),
+        onTick: () => this.runScheduled(),
         start: false,
         name: 'payout',
       });
@@ -54,6 +58,37 @@ export default {
 
       throw error;
     }
+  },
+
+  /**
+   * Runs a scheduled payout. When the pool is locked, the run is recorded as
+   * deferred (so it can be picked up on unlock) before the payer reports the
+   * locked state.
+   * @returns {Promise<void>}
+   */
+  async runScheduled() {
+    if (!secret.isUnlocked()) {
+      this.deferredPayout = true;
+    }
+
+    await payer.payOut();
+  },
+
+  /**
+   * Processes a payout that was due while the pool was locked. No-op when no
+   * scheduled run was missed.
+   * @returns {Promise<void>}
+   */
+  async runDeferred() {
+    if (!this.deferredPayout) {
+      return;
+    }
+
+    this.deferredPayout = false;
+
+    log.info('Processing reward payouts that were deferred while the pool was locked.');
+
+    await payer.payOut();
   },
 };
 

--- a/server/src/cron/payout.cron.js
+++ b/server/src/cron/payout.cron.js
@@ -76,19 +76,29 @@ export default {
 
   /**
    * Processes a payout that was due while the pool was locked. No-op when no
-   * scheduled run was missed.
+   * scheduled run was missed or the pool is locked again. The deferred marker is
+   * cleared only after an attempt actually runs while unlocked, so an immediate
+   * re-lock or a payout error does not drop the missed run — a later unlock
+   * replays it.
    * @returns {Promise<void>}
    */
   async runDeferred() {
-    if (!this.deferredPayout) {
+    if (!this.deferredPayout || !secret.isUnlocked()) {
       return;
     }
 
-    this.deferredPayout = false;
-
     log.info('Processing reward payouts that were deferred while the pool was locked.');
 
-    await payer.payOut();
+    try {
+      await payer.payOut();
+
+      // payOut() owns its own retry scheduling for partial failures, so a
+      // completed attempt clears the deferred marker.
+      this.deferredPayout = false;
+    } catch (error) {
+      // Keep the marker set so the next unlock retries the missed payout.
+      log.error(`Deferred payout attempt failed, keeping it pending for the next unlock: ${error}`);
+    }
   },
 };
 

--- a/server/src/defines.js
+++ b/server/src/defines.js
@@ -6,6 +6,8 @@ export const RETRY_WHEN_UPDATING_VOTERS_TIMEOUT = 10 * 1000;
 export const RETRY_PAYOUTS_TIMEOUT = 10 * 60 * 1000;
 export const RETRY_PAYOUTS_COUNT = 3; // re-tries for payouts. Total tries RETRY_PAYOUTS_COUNT + 1;
 export const UPDATE_AFTER_PAYMENT_DELAY = 60 * 1000; // Wait 1 minute to update pool's balance and notify
+// Let the burst of startup logs flush before showing the interactive unlock prompt.
+export const UNLOCK_PROMPT_DELAY = 2000;
 export const SAT = 100000000; // 1 ADM = 100000000
 export const DEVIATION = 100000; // consider balance is zero when it is lower; then 0.001 ADM
 export const FEE = 0.5; // Transfer (Type 0) Tx fee;

--- a/server/src/helpers/config/reader.js
+++ b/server/src/helpers/config/reader.js
@@ -1,5 +1,4 @@
 import * as process from 'node:process';
-import { createAddressFromPublicKey, createKeypairFromPassphrase } from 'adamant-api';
 import fs from 'fs';
 import jsonminify from 'jsonminify';
 
@@ -8,6 +7,9 @@ import { fileURLToPath } from 'url';
 
 import configSchema from './schema.js';
 import validateConfig from './validate.js';
+
+import { deriveIdentity, isEncrypted, parseHeader } from '../crypto/passphrase.js';
+import secret from '../../modules/secret.js';
 
 import { EXIT_CODE_ERROR, MIN_PAYOUT } from '../../defines.js';
 
@@ -71,17 +73,33 @@ if (!config.passPhrase) {
   exit('Pool\'s config is wrong. No passPhrase. Cannot start Pool.');
 }
 
-let keysPair;
+let publicKey;
+let address;
 
-try {
-  keysPair = createKeypairFromPassphrase(config.passPhrase);
-} catch (error) {
-  exit('Pool\'s config is wrong. Invalid passPhrase. Cannot start Pool. Error: ', error);
+// The passPhrase is either a plain phrase (derive the keypair now) or an
+// operator-encrypted blob (read the public identity from its header and stay
+// LOCKED until `adm-pool unlock`). Detection is deterministic, never heuristic.
+if (isEncrypted(config.passPhrase)) {
+  try {
+    const header = parseHeader(config.passPhrase);
+    publicKey = header.publicKey;
+    address = header.address;
+  } catch (error) {
+    exit('Pool\'s config is wrong. Invalid encrypted passPhrase. Cannot start Pool. Error: ', error);
+  }
+
+  secret.initEncrypted(config.passPhrase);
+} else {
+  try {
+    ({ publicKey, address } = deriveIdentity(config.passPhrase));
+  } catch (error) {
+    exit('Pool\'s config is wrong. Invalid passPhrase. Cannot start Pool. Error: ', error);
+  }
+
+  secret.initPlain(config.passPhrase, publicKey, address);
 }
 
-const address = createAddressFromPublicKey(keysPair.publicKey);
-
-config.publicKey = keysPair.publicKey.toString('hex');
+config.publicKey = publicKey;
 config.address = address;
 
 // Until the delegate is fetched, identify the pool by address only — the account
@@ -106,7 +124,10 @@ if (config.poolsShare < 0) {
 
 config.payoutperiod = config.payoutperiod[0].toUpperCase() + config.payoutperiod.slice(1).toLowerCase();
 
-console.info(`Pool ${address} successfully read config file (${loadedConfigPath ? loadedConfigPath : 'default'}).`);
+// The `adm-pool` CLI imports this module only to resolve config; keep its output clean.
+if (!process.env.ADM_POOL_CLI) {
+  console.info(`Pool ${address} successfully read config file (${loadedConfigPath ? loadedConfigPath : 'default'}).`);
+}
 
 /**
  * Logs fatal config errors and terminates the process.

--- a/server/src/helpers/config/schema.js
+++ b/server/src/helpers/config/schema.js
@@ -52,6 +52,10 @@ export default {
     default: 'log',
     allowedValues: ['none', 'error', 'warn', 'info', 'log', 'debug'],
   },
+  controlSocket: {
+    type: String,
+    default: null,
+  },
   silent_mode: {
     type: Boolean,
     default: false,

--- a/server/src/helpers/control/socketPath.js
+++ b/server/src/helpers/control/socketPath.js
@@ -2,10 +2,23 @@ import os from 'node:os';
 import path from 'node:path';
 
 /**
+ * Returns the private per-user runtime directory that holds the default control
+ * socket. Scoping the directory to the current user (and creating it `0700` in
+ * the server) keeps the default socket out of the shared, world-writable system
+ * temp root, so a local attacker cannot pre-create the predictable socket path.
+ * @returns {string} Per-user runtime directory path
+ */
+export function controlSocketDir() {
+  const userId = typeof process.getuid === 'function' ? process.getuid() : os.userInfo().username;
+
+  return path.join(os.tmpdir(), `adamant-pool-${userId}`);
+}
+
+/**
  * Resolves the Unix domain socket path used by the `adm-pool` control CLI to
  * talk to a running pool. A `controlSocket` config value takes precedence;
- * otherwise the path is derived from the pool's port so multiple pools on one
- * host do not collide.
+ * otherwise the path is derived from the pool's port inside the private per-user
+ * runtime directory so multiple pools on one host do not collide.
  * @param {object} config Loaded pool configuration
  * @returns {string} Absolute path to the control socket
  */
@@ -14,5 +27,5 @@ export function resolveControlSocketPath(config) {
     return config.controlSocket;
   }
 
-  return path.join(os.tmpdir(), `adamant-pool-${config.port}-control.sock`);
+  return path.join(controlSocketDir(), `control-${config.port}.sock`);
 }

--- a/server/src/helpers/control/socketPath.js
+++ b/server/src/helpers/control/socketPath.js
@@ -1,0 +1,18 @@
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Resolves the Unix domain socket path used by the `adm-pool` control CLI to
+ * talk to a running pool. A `controlSocket` config value takes precedence;
+ * otherwise the path is derived from the pool's port so multiple pools on one
+ * host do not collide.
+ * @param {object} config Loaded pool configuration
+ * @returns {string} Absolute path to the control socket
+ */
+export function resolveControlSocketPath(config) {
+  if (config.controlSocket) {
+    return config.controlSocket;
+  }
+
+  return path.join(os.tmpdir(), `adamant-pool-${config.port}-control.sock`);
+}

--- a/server/src/helpers/crypto/passphrase.js
+++ b/server/src/helpers/crypto/passphrase.js
@@ -1,0 +1,206 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+  scryptSync,
+  timingSafeEqual,
+} from 'node:crypto';
+
+import { createAddressFromPublicKey, createKeypairFromPassphrase } from 'adamant-api';
+
+/**
+ * Self-describing prefix that marks an encrypted passphrase blob.
+ * Detection is deterministic: a value is encrypted if and only if it starts with this prefix.
+ */
+export const ENCRYPTED_PREFIX = 'admpool-enc-v1.';
+
+/**
+ * scrypt key-derivation parameters. `N` is the CPU/memory cost (2^15),
+ * `keylen` is 32 bytes for AES-256. `maxmem` is raised so Node allows the chosen cost.
+ */
+const KDF = {
+  name: 'scrypt',
+  N: 1 << 15,
+  r: 8,
+  p: 1,
+  keylen: 32,
+  maxmem: 96 * 1024 * 1024,
+};
+
+const CIPHER = 'aes-256-gcm';
+const SALT_LENGTH = 16;
+const IV_LENGTH = 12;
+
+/**
+ * Reports whether a config value is an encrypted passphrase blob.
+ * Detection is deterministic (prefix match), never a heuristic on length or charset.
+ * @param {unknown} value Config value to test
+ * @returns {boolean} True when the value is an encrypted passphrase blob
+ */
+export function isEncrypted(value) {
+  return typeof value === 'string' && value.startsWith(ENCRYPTED_PREFIX);
+}
+
+/**
+ * Derives the public key (hex) and ADM address for a plain passphrase.
+ * @param {string} passphrase Plain ADAMANT passphrase
+ * @returns {{publicKey: string, address: string}} Derived public key and address
+ */
+export function deriveIdentity(passphrase) {
+  const keysPair = createKeypairFromPassphrase(passphrase);
+  const publicKey = keysPair.publicKey.toString('hex');
+  const address = createAddressFromPublicKey(keysPair.publicKey);
+
+  return { publicKey, address };
+}
+
+/**
+ * Derives a 32-byte AES key from the operator password and salt via scrypt.
+ * @param {string} password Operator password
+ * @param {Buffer} salt KDF salt
+ * @returns {Buffer} 32-byte symmetric key
+ */
+function deriveKey(password, salt) {
+  return scryptSync(password, salt, KDF.keylen, {
+    N: KDF.N,
+    r: KDF.r,
+    p: KDF.p,
+    maxmem: KDF.maxmem,
+  });
+}
+
+/**
+ * Encrypts a plain passphrase with an operator password.
+ *
+ * The result is a single self-describing string: the {@link ENCRYPTED_PREFIX}
+ * followed by base64url-encoded JSON containing the KDF parameters, salt, IV,
+ * auth tag, ciphertext, and the (non-secret) derived public key and address so
+ * the pool can run read-only operations while still locked.
+ * @param {string} passphrase Plain ADAMANT passphrase to encrypt
+ * @param {string} password Operator password used to derive the encryption key
+ * @returns {string} Encrypted passphrase blob
+ * @throws {Error} When the passphrase or password is empty, or the passphrase is invalid
+ */
+export function encrypt(passphrase, password) {
+  if (!passphrase) {
+    throw new Error('Passphrase is required.');
+  }
+  if (!password) {
+    throw new Error('Operator password is required.');
+  }
+
+  // Fails fast on an invalid passphrase and gives us the public identity to embed.
+  const { publicKey, address } = deriveIdentity(passphrase);
+
+  const salt = randomBytes(SALT_LENGTH);
+  const iv = randomBytes(IV_LENGTH);
+  const key = deriveKey(password, salt);
+
+  const cipher = createCipheriv(CIPHER, key, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(passphrase, 'utf8'),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+
+  const header = {
+    kdf: KDF.name,
+    N: KDF.N,
+    r: KDF.r,
+    p: KDF.p,
+    cipher: CIPHER,
+    salt: salt.toString('base64'),
+    iv: iv.toString('base64'),
+    tag: tag.toString('base64'),
+    ct: ciphertext.toString('base64'),
+    publicKey,
+    address,
+  };
+
+  const encoded = Buffer.from(JSON.stringify(header), 'utf8').toString('base64url');
+
+  return `${ENCRYPTED_PREFIX}${encoded}`;
+}
+
+/**
+ * Parses the non-secret header of an encrypted passphrase blob without decrypting it.
+ * @param {string} blob Encrypted passphrase blob
+ * @returns {{publicKey: string, address: string, kdf: string, cipher: string}} Public metadata
+ * @throws {Error} When the value is not a valid encrypted passphrase blob
+ */
+export function parseHeader(blob) {
+  if (!isEncrypted(blob)) {
+    throw new Error('Value is not an encrypted passphrase blob.');
+  }
+
+  let header;
+
+  try {
+    const encoded = blob.slice(ENCRYPTED_PREFIX.length);
+    header = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'));
+  } catch {
+    throw new Error('Encrypted passphrase blob is malformed.');
+  }
+
+  if (!header.publicKey || !header.address || !header.ct) {
+    throw new Error('Encrypted passphrase blob is missing required fields.');
+  }
+
+  return header;
+}
+
+/**
+ * Decrypts an encrypted passphrase blob with the operator password.
+ *
+ * The decrypted passphrase is verified against the public key embedded in the
+ * blob header, so a tampered blob or a wrong-but-valid passphrase is rejected.
+ * @param {string} blob Encrypted passphrase blob
+ * @param {string} password Operator password used during encryption
+ * @returns {{passphrase: string, publicKey: string, address: string}} Decrypted passphrase and identity
+ * @throws {Error} When the password is wrong or the blob is tampered/malformed
+ */
+export function decrypt(blob, password) {
+  if (!password) {
+    throw new Error('Operator password is required.');
+  }
+
+  const header = parseHeader(blob);
+
+  const salt = Buffer.from(header.salt, 'base64');
+  const iv = Buffer.from(header.iv, 'base64');
+  const tag = Buffer.from(header.tag, 'base64');
+  const ciphertext = Buffer.from(header.ct, 'base64');
+
+  const key = scryptSync(password, salt, KDF.keylen, {
+    N: header.N ?? KDF.N,
+    r: header.r ?? KDF.r,
+    p: header.p ?? KDF.p,
+    maxmem: KDF.maxmem,
+  });
+
+  let passphrase;
+
+  try {
+    const decipher = createDecipheriv(header.cipher ?? CIPHER, key, iv);
+    decipher.setAuthTag(tag);
+
+    passphrase = Buffer.concat([
+      decipher.update(ciphertext),
+      decipher.final(),
+    ]).toString('utf8');
+  } catch {
+    // GCM auth failure: wrong password or tampered ciphertext.
+    throw new Error('Wrong operator password or corrupted encrypted passphrase.');
+  }
+
+  const derived = deriveIdentity(passphrase);
+
+  const expected = Buffer.from(header.publicKey, 'hex');
+  const actual = Buffer.from(derived.publicKey, 'hex');
+
+  if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) {
+    throw new Error('Decrypted passphrase does not match the embedded public key.');
+  }
+
+  return { passphrase, publicKey: derived.publicKey, address: derived.address };
+}

--- a/server/src/helpers/notify.js
+++ b/server/src/helpers/notify.js
@@ -2,6 +2,7 @@ import adamantApiClient from './adamantApiClient.js';
 import axios from 'axios';
 import config from './config/reader.js';
 import log from './log.js';
+import secret from '../modules/secret.js';
 
 const {
   adamant_notify: adamantNotify,
@@ -54,10 +55,14 @@ export default (message, type, silentMode = false) => {
             });
       }
 
-      if (adamantNotify && adamantNotify.length > 5 && adamantNotify.startsWith('U') && config.passPhrase && config.passPhrase.length > 30) {
+      // ADM notifications require signing, so they are sent only while unlocked.
+      // Slack (above) keeps working when the pool is locked.
+      const passPhrase = secret.getPassphrase();
+
+      if (adamantNotify && adamantNotify.length > 5 && adamantNotify.startsWith('U') && passPhrase && passPhrase.length > 30) {
         const mdMessage = makeBoldForMarkdown(message);
 
-        adamantApiClient.sendMessage(config.passPhrase, adamantNotify, `${type}| ${mdMessage}`)
+        adamantApiClient.sendMessage(passPhrase, adamantNotify, `${type}| ${mdMessage}`)
             .then((response) => {
               if (!response.success) {
                 log.warn(`Failed to send notification message '${mdMessage}' to ${adamantNotify}. ${response.errorMessage}.`);

--- a/server/src/helpers/prompt.js
+++ b/server/src/helpers/prompt.js
@@ -13,29 +13,14 @@ import readline from 'node:readline';
 export function promptHidden(query) {
   return new Promise((resolve) => {
     const { stdin, stderr } = process;
-    const isTTY = Boolean(stdin.isTTY);
 
-    // Prompts and echo go to stderr so stdout carries only command output.
-    const rl = readline.createInterface({
-      input: stdin,
-      output: stderr,
-      terminal: isTTY,
-    });
+    // Non-interactive fallback: read a line without masking (the input is piped,
+    // so it is not visible anyway). EOF before an answer resolves to ''.
+    if (!stdin.isTTY || typeof stdin.setRawMode !== 'function') {
+      const rl = readline.createInterface({ input: stdin, output: stderr, terminal: false });
 
-    // Resolve to '' if the stream ends before an answer (e.g. EOF on a pipe).
-    rl.on('close', () => resolve(''));
-
-    if (isTTY) {
-      // Mask everything readline would echo; only render the newline on Enter.
-      rl._writeToOutput = (chunk) => {
-        if (chunk === '\r\n' || chunk === '\n' || chunk === '\r') {
-          rl.output.write('\n');
-        }
-      };
-
-      stderr.write(query);
-
-      rl.question('', (answer) => {
+      rl.on('close', () => resolve(''));
+      rl.question(query, (answer) => {
         rl.close();
         resolve(answer);
       });
@@ -43,10 +28,63 @@ export function promptHidden(query) {
       return;
     }
 
-    rl.question(query, (answer) => {
-      rl.close();
-      resolve(answer);
-    });
+    // Interactive: enable raw mode first (disables terminal echo), then render
+    // the prompt and read keystrokes, echoing only a mask so the prompt stays
+    // visible and the secret is never shown.
+    const wasRaw = stdin.isRaw;
+    let input = '';
+
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding('utf8');
+
+    stderr.write(query);
+
+    const finish = (value) => {
+      stdin.removeListener('data', onData);
+      stdin.setRawMode(wasRaw);
+      stdin.pause();
+      stderr.write('\n');
+      resolve(value);
+    };
+
+    const onData = (chunk) => {
+      for (const char of chunk) {
+        // Enter (CR/LF) or Ctrl-D finishes the input.
+        if (char === '\n' || char === '\r' || char === '\u0004') {
+          finish(input);
+          return;
+        }
+
+        // Ctrl-C aborts.
+        if (char === '\u0003') {
+          stdin.setRawMode(wasRaw);
+          stdin.pause();
+          stderr.write('\n');
+          process.exit(130);
+        }
+
+        // Backspace / Delete removes the last character.
+        if (char === '\u007f' || char === '\b') {
+          if (input.length > 0) {
+            input = input.slice(0, -1);
+            stderr.write('\b \b');
+          }
+
+          continue;
+        }
+
+        // Ignore other control characters (arrows, etc.).
+        if (char < ' ') {
+          continue;
+        }
+
+        input += char;
+        stderr.write('*');
+      }
+    };
+
+    stdin.on('data', onData);
   });
 }
 

--- a/server/src/helpers/prompt.js
+++ b/server/src/helpers/prompt.js
@@ -1,0 +1,93 @@
+import readline from 'node:readline';
+
+/**
+ * Prompts for a line of input on stdin, masking the typed characters when a
+ * terminal is attached so passphrases and operator passwords are never echoed.
+ *
+ * When stdin is not a TTY (piped or redirected input), the line is read without
+ * masking — the input is not visible on screen anyway — and an EOF before any
+ * answer resolves to an empty string so callers never hang.
+ * @param {string} query Prompt text to display
+ * @returns {Promise<string>} The entered value (without the trailing newline)
+ */
+export function promptHidden(query) {
+  return new Promise((resolve) => {
+    const { stdin, stderr } = process;
+    const isTTY = Boolean(stdin.isTTY);
+
+    // Prompts and echo go to stderr so stdout carries only command output.
+    const rl = readline.createInterface({
+      input: stdin,
+      output: stderr,
+      terminal: isTTY,
+    });
+
+    // Resolve to '' if the stream ends before an answer (e.g. EOF on a pipe).
+    rl.on('close', () => resolve(''));
+
+    if (isTTY) {
+      // Mask everything readline would echo; only render the newline on Enter.
+      rl._writeToOutput = (chunk) => {
+        if (chunk === '\r\n' || chunk === '\n' || chunk === '\r') {
+          rl.output.write('\n');
+        }
+      };
+
+      stderr.write(query);
+
+      rl.question('', (answer) => {
+        rl.close();
+        resolve(answer);
+      });
+
+      return;
+    }
+
+    rl.question(query, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}
+
+/**
+ * Creates a prompter for reading one or more hidden inputs in sequence.
+ *
+ * With a terminal attached each prompt is read interactively and masked. When
+ * stdin is piped/redirected (tests, automation), the whole input is buffered
+ * once and the prompts consume it line by line, which avoids losing lines
+ * across multiple readline interfaces.
+ * @returns {{ask: (query: string) => Promise<string>}} A prompter with an async `ask`
+ */
+export function createHiddenPrompter() {
+  if (process.stdin.isTTY) {
+    return { ask: promptHidden };
+  }
+
+  let linesPromise = null;
+  let index = 0;
+
+  const loadLines = () => new Promise((resolve) => {
+    let data = '';
+
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+    process.stdin.once('end', () => resolve(data.split(/\r?\n/)));
+  });
+
+  return {
+    async ask(query) {
+      process.stderr.write(query);
+
+      if (!linesPromise) {
+        linesPromise = loadLines();
+      }
+
+      const lines = await linesPromise;
+
+      return lines[index++] ?? '';
+    },
+  };
+}

--- a/server/src/modules/health.js
+++ b/server/src/modules/health.js
@@ -1,0 +1,56 @@
+import config from '../helpers/config/reader.js';
+import secret from './secret.js';
+import store from './store.js';
+
+/**
+ * Whether the ADAMANT node connection has completed its startup health check.
+ * Flipped to true by app.js once `adamantApiClient.onReady` fires.
+ */
+let nodeReady = false;
+
+/**
+ * Marks the ADAMANT node connection as ready (or not) for health reporting.
+ * @param {boolean} ready Node readiness flag
+ * @returns {void}
+ */
+export function setNodeReady(ready) {
+  nodeReady = Boolean(ready);
+}
+
+/**
+ * Builds a secret-free health snapshot of the pool for monitoring (e.g. Zabbix)
+ * and for the `adm-pool status` command.
+ *
+ * `status` is `starting` until the node is ready, `degraded` while the pool is
+ * locked (payouts and ADM notifications are paused), and `ok` otherwise.
+ * @returns {object} Health snapshot containing no secrets
+ */
+export function buildHealth() {
+  const { mode, locked, address } = secret.status();
+
+  let status = 'ok';
+
+  if (!nodeReady) {
+    status = 'starting';
+  } else if (locked) {
+    status = 'degraded';
+  }
+
+  return {
+    status,
+    version: config.version,
+    uptime: Math.floor(process.uptime()),
+    address,
+    delegate: config.poolName || null,
+    payouts: locked ? 'locked' : 'unlocked',
+    passphrase: mode === 'encrypted' ? 'encrypted' : 'plain',
+    node: {
+      ready: nodeReady,
+      rank: store.delegate.rank,
+      productivity: store.delegate.productivity,
+    },
+    pendingRewardsADM: store.delegate.pendingRewardsADM,
+    lastPayoutTimestamp: store.periodInfo.previousRunTimestamp || null,
+    nextPayoutTimestamp: store.periodInfo.nextRunTimestamp || null,
+  };
+}

--- a/server/src/modules/pay_out.js
+++ b/server/src/modules/pay_out.js
@@ -5,6 +5,7 @@ import {
   SAT,
 } from '../defines.js';
 import store, { normalizePendingReward } from './store.js';
+import secret from './secret.js';
 
 import { adamantApiClient, config, log, notifier } from '../helpers/index.js';
 import mongo from '../repository/mongodb/index.js';
@@ -27,6 +28,17 @@ class Payer {
    * @returns {Promise<void>}
    */
   async payOut() {
+    // When the passphrase is encrypted and not yet unlocked, the pool cannot
+    // sign transactions. Pending rewards stay in the database and are paid out
+    // once the operator runs `adm-pool unlock`, so nothing is lost.
+    if (!secret.isUnlocked()) {
+      return notifier(
+          `Pool ${config.logName}: Payouts are LOCKED — the encrypted passphrase has not been unlocked. ` +
+          'Run `adm-pool unlock` to enable payouts. Pending rewards are preserved and paid after unlock.',
+          'warn',
+      );
+    }
+
     await this.updateVoters();
 
     const { votersToReward, pendingUserRewards, periodInfo } = this;
@@ -188,7 +200,7 @@ class Payer {
     log.debug(`Preparing payout for ${address}: Pending ${pending.toFixed(8)} ADM, fee ${FEE} ADM.`);
     log.debug(`Processing payment of ${amount.toFixed(8)} ADM reward to ${address}…`);
 
-    const payment = await adamantApiClient.sendTokens(config.passPhrase, address, amount);
+    const payment = await adamantApiClient.sendTokens(secret.getPassphrase(), address, amount);
 
     if (!payment.success) {
       return log.warn(
@@ -275,7 +287,7 @@ class Payer {
             log.debug(`Processing payment of ${logPayAmount} to the maintenance wallet ${config.maintenancewallet}…`);
 
             const paymentMaintenance = await adamantApiClient.sendTokens(
-                config.passPhrase,
+                secret.getPassphrase(),
                 config.maintenancewallet,
                 maintenanceADM - FEE,
             );
@@ -335,7 +347,7 @@ class Payer {
         log.debug(`Processing payment of ${logDonationAmount} to the donation wallet ${config.donatewallet}…`);
 
         const paymentDonate = await adamantApiClient.sendTokens(
-            config.passPhrase,
+            secret.getPassphrase(),
             config.donatewallet,
             donateADM - FEE,
         );

--- a/server/src/modules/secret.js
+++ b/server/src/modules/secret.js
@@ -1,0 +1,137 @@
+import { EventEmitter } from 'node:events';
+
+import { decrypt, parseHeader } from '../helpers/crypto/passphrase.js';
+
+/**
+ * Runtime store for the pool's passphrase and its lock state.
+ *
+ * Two modes:
+ * - `plain`: the config holds a plain passphrase; the pool is always unlocked.
+ * - `encrypted`: the config holds an encrypted blob; the pool boots LOCKED and
+ *   the passphrase only exists in memory after a successful {@link unlock}.
+ *
+ * The passphrase is never written to disk or logs. On restart it must be supplied again.
+ * Emits an `unlock` event so callers (e.g. payout catch-up) can react.
+ */
+class Secret extends EventEmitter {
+  constructor() {
+    super();
+
+    this.mode = 'plain';
+    this.locked = false;
+    this.publicKey = null;
+    this.address = null;
+
+    this._passphrase = null;
+    this._blob = null;
+  }
+
+  /**
+   * Initializes the store for a plain (unencrypted) passphrase.
+   * @param {string} passphrase Plain ADAMANT passphrase
+   * @param {string} publicKey Derived public key (hex)
+   * @param {string} address Derived ADM address
+   * @returns {void}
+   */
+  initPlain(passphrase, publicKey, address) {
+    this.mode = 'plain';
+    this.locked = false;
+    this.publicKey = publicKey;
+    this.address = address;
+    this._passphrase = passphrase;
+    this._blob = null;
+  }
+
+  /**
+   * Initializes the store for an encrypted passphrase, starting in the LOCKED state.
+   * @param {string} blob Encrypted passphrase blob
+   * @returns {void}
+   * @throws {Error} When the blob is malformed
+   */
+  initEncrypted(blob) {
+    const header = parseHeader(blob);
+
+    this.mode = 'encrypted';
+    this.locked = true;
+    this.publicKey = header.publicKey;
+    this.address = header.address;
+    this._passphrase = null;
+    this._blob = blob;
+  }
+
+  /**
+   * Whether the passphrase is available for signing (payouts and ADM notifications).
+   * @returns {boolean} True when a passphrase is loaded in memory
+   */
+  isUnlocked() {
+    return !this.locked && Boolean(this._passphrase);
+  }
+
+  /**
+   * Returns the passphrase when unlocked, otherwise null.
+   * @returns {string|null} Passphrase available for signing, or null when locked
+   */
+  getPassphrase() {
+    return this.isUnlocked() ? this._passphrase : null;
+  }
+
+  /**
+   * Decrypts and loads the passphrase with the operator password (encrypted mode only).
+   * @param {string} password Operator password
+   * @returns {{address: string}} The unlocked pool's address
+   * @throws {Error} When already unlocked, not in encrypted mode, or the password is wrong
+   */
+  unlock(password) {
+    if (this.mode !== 'encrypted') {
+      throw new Error('Pool passphrase is not encrypted; nothing to unlock.');
+    }
+    if (this.isUnlocked()) {
+      throw new Error('Pool is already unlocked.');
+    }
+
+    const { passphrase, publicKey, address } = decrypt(this._blob, password);
+
+    this._passphrase = passphrase;
+    this.publicKey = publicKey;
+    this.address = address;
+    this.locked = false;
+
+    this.emit('unlock', { address });
+
+    return { address };
+  }
+
+  /**
+   * Clears the decrypted passphrase from memory (encrypted mode only).
+   * @returns {void}
+   * @throws {Error} When the pool runs with a plain passphrase
+   */
+  lock() {
+    if (this.mode !== 'encrypted') {
+      throw new Error('Pool passphrase is not encrypted; it cannot be locked.');
+    }
+
+    this._passphrase = null;
+    this.locked = true;
+
+    this.emit('lock', { address: this.address });
+  }
+
+  /**
+   * Returns a secret-free snapshot of the current lock state.
+   * @returns {{mode: string, locked: boolean, unlocked: boolean, publicKey: string|null, address: string|null}}
+   */
+  status() {
+    return {
+      mode: this.mode,
+      locked: this.locked,
+      unlocked: this.isUnlocked(),
+      publicKey: this.publicKey,
+      address: this.address,
+    };
+  }
+}
+
+const secret = new Secret();
+
+export default secret;

--- a/server/tests/helpers/cron_deferred.test.js
+++ b/server/tests/helpers/cron_deferred.test.js
@@ -1,0 +1,102 @@
+import { jest } from '@jest/globals';
+
+const payOut = jest.fn();
+let unlocked = true;
+
+jest.unstable_mockModule('../../src/modules/pay_out.js', () => ({
+  __esModule: true,
+  default: class Payer {
+    payOut(...args) {
+      return payOut(...args);
+    }
+  },
+}));
+
+jest.unstable_mockModule('../../src/modules/secret.js', () => ({
+  __esModule: true,
+  default: {
+    isUnlocked: () => unlocked,
+  },
+}));
+
+jest.unstable_mockModule('../../src/helpers/config/reader.js', () => ({
+  __esModule: true,
+  default: { address: 'U1', payoutperiod: '1d' },
+}));
+
+jest.unstable_mockModule('../../src/helpers/log.js', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    log: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const cron = (await import('../../src/cron/payout.cron.js')).default;
+
+describe('Deferred payout marker', () => {
+  beforeEach(() => {
+    payOut.mockReset();
+    payOut.mockResolvedValue(undefined);
+    cron.deferredPayout = false;
+    unlocked = true;
+  });
+
+  describe('runScheduled', () => {
+    it('marks the payout deferred when the pool is locked', async () => {
+      unlocked = false;
+
+      await cron.runScheduled();
+
+      expect(cron.deferredPayout).toBe(true);
+      expect(payOut).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not mark a deferred payout when the pool is unlocked', async () => {
+      await cron.runScheduled();
+
+      expect(cron.deferredPayout).toBe(false);
+      expect(payOut).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('runDeferred', () => {
+    it('does nothing when no payout was deferred', async () => {
+      await cron.runDeferred();
+
+      expect(payOut).not.toHaveBeenCalled();
+    });
+
+    it('keeps the marker and does not pay when the pool is locked again', async () => {
+      cron.deferredPayout = true;
+      unlocked = false;
+
+      await cron.runDeferred();
+
+      expect(payOut).not.toHaveBeenCalled();
+      expect(cron.deferredPayout).toBe(true);
+    });
+
+    it('runs the payout and clears the marker after a successful unlocked attempt', async () => {
+      cron.deferredPayout = true;
+
+      await cron.runDeferred();
+
+      expect(payOut).toHaveBeenCalledTimes(1);
+      expect(cron.deferredPayout).toBe(false);
+    });
+
+    it('keeps the marker when the payout attempt throws', async () => {
+      cron.deferredPayout = true;
+      payOut.mockRejectedValue(new Error('node down'));
+
+      await cron.runDeferred();
+
+      expect(payOut).toHaveBeenCalledTimes(1);
+      expect(cron.deferredPayout).toBe(true);
+    });
+  });
+});

--- a/server/tests/helpers/passphrase_crypto.test.js
+++ b/server/tests/helpers/passphrase_crypto.test.js
@@ -1,0 +1,88 @@
+import {
+  ENCRYPTED_PREFIX,
+  decrypt,
+  deriveIdentity,
+  encrypt,
+  isEncrypted,
+  parseHeader,
+} from '../../src/helpers/crypto/passphrase.js';
+
+const PASSPHRASE = 'apple banana cherry dog elephant frog grape house ice juice kite lemon';
+const PASSWORD = 'correct horse battery staple';
+
+describe('passphrase crypto', () => {
+  describe('isEncrypted', () => {
+    it('detects encrypted blobs deterministically by prefix', () => {
+      const blob = encrypt(PASSPHRASE, PASSWORD);
+
+      expect(isEncrypted(blob)).toBe(true);
+      expect(blob.startsWith(ENCRYPTED_PREFIX)).toBe(true);
+    });
+
+    it('treats a plain passphrase as not encrypted', () => {
+      expect(isEncrypted(PASSPHRASE)).toBe(false);
+      expect(isEncrypted('')).toBe(false);
+      expect(isEncrypted(undefined)).toBe(false);
+      expect(isEncrypted(123)).toBe(false);
+    });
+  });
+
+  describe('encrypt/decrypt round trip', () => {
+    it('recovers the original passphrase with the right password', () => {
+      const blob = encrypt(PASSPHRASE, PASSWORD);
+      const result = decrypt(blob, PASSWORD);
+
+      expect(result.passphrase).toBe(PASSPHRASE);
+    });
+
+    it('produces a different blob each time (random salt/iv)', () => {
+      expect(encrypt(PASSPHRASE, PASSWORD)).not.toBe(encrypt(PASSPHRASE, PASSWORD));
+    });
+
+    it('embeds the public identity for locked-mode reads', () => {
+      const identity = deriveIdentity(PASSPHRASE);
+      const header = parseHeader(encrypt(PASSPHRASE, PASSWORD));
+
+      expect(header.publicKey).toBe(identity.publicKey);
+      expect(header.address).toBe(identity.address);
+      expect(header.address.startsWith('U')).toBe(true);
+    });
+  });
+
+  describe('decrypt failures', () => {
+    it('rejects a wrong password', () => {
+      const blob = encrypt(PASSPHRASE, PASSWORD);
+
+      expect(() => decrypt(blob, 'wrong password')).toThrow(/Wrong operator password/);
+    });
+
+    it('rejects a tampered ciphertext', () => {
+      const blob = encrypt(PASSPHRASE, PASSWORD);
+      const header = parseHeader(blob);
+
+      const tamperedCt = Buffer.from(header.ct, 'base64');
+      tamperedCt[0] ^= 0xff;
+      header.ct = tamperedCt.toString('base64');
+
+      const tamperedBlob = ENCRYPTED_PREFIX +
+        Buffer.from(JSON.stringify(header), 'utf8').toString('base64url');
+
+      expect(() => decrypt(tamperedBlob, PASSWORD)).toThrow();
+    });
+
+    it('requires a non-empty passphrase and password to encrypt', () => {
+      expect(() => encrypt('', PASSWORD)).toThrow(/Passphrase is required/);
+      expect(() => encrypt(PASSPHRASE, '')).toThrow(/Operator password is required/);
+    });
+  });
+
+  describe('parseHeader', () => {
+    it('throws on a non-encrypted value', () => {
+      expect(() => parseHeader(PASSPHRASE)).toThrow(/not an encrypted/);
+    });
+
+    it('throws on a malformed blob', () => {
+      expect(() => parseHeader(`${ENCRYPTED_PREFIX}not-base64-json`)).toThrow();
+    });
+  });
+});

--- a/server/tests/modules/pay_out.test.js
+++ b/server/tests/modules/pay_out.test.js
@@ -35,6 +35,14 @@ jest.unstable_mockModule('../../src/helpers/index.js', () => ({
   notifier,
 }));
 
+jest.unstable_mockModule('../../src/modules/secret.js', () => ({
+  __esModule: true,
+  default: {
+    isUnlocked: () => true,
+    getPassphrase: () => 'test passphrase',
+  },
+}));
+
 jest.unstable_mockModule('../../src/modules/store.js', () => ({
   __esModule: true,
   default: {

--- a/web/jsconfig.json
+++ b/web/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "target": "ESNext",
     "module": "ESNext",
     /**
@@ -8,7 +8,7 @@
      * a value or a type, so tell TypeScript to enforce using
      * `import type` instead of `import` for Types.
      */
-    "importsNotUsedAsValues": "error",
+    "verbatimModuleSyntax": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
     /**
@@ -19,7 +19,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
     /**
      * Typecheck JS in `.svelte` and `.js` files by default.
      * Disable this if you'd like to use dynamic types.

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -73,6 +73,9 @@
           {store?.delegate.username}
         </a>
       </b>
+      {#if system?.locked}
+        <span class="text-amber-600">(waiting for password to unlock payouts…)</span>
+      {/if}
       distributes {system?.reward_percentage}% rewards to
       voters {system?.donate_percentage ? `and donates ${system?.donate_percentage}% to ADAMANT developer community` : '' } with
       payouts every {system?.payoutperiod}. Minimum payout is {system?.minpayout} ADM.


### PR DESCRIPTION
## Description

Adds optional operator-password encryption for the pool passphrase, an `adm-pool` control CLI to manage it, and an `/api/health` endpoint for external monitoring. A plain passphrase still works unchanged, so the change is backward compatible.

Passphrase encryption:

- encrypts the passphrase with AES-256-GCM and a key derived from the operator password via scrypt, using only Node's built-in `crypto` (no new dependencies)
- stores the result as a self-describing `admpool-enc-v1.` blob (KDF params, salt, IV, auth tag, ciphertext) so plain vs encrypted detection is deterministic, never a heuristic
- embeds the non-secret public key and address in the blob so the pool can run read-only work while locked, and verifies the decrypted passphrase against that public key on unlock
- the operator password and decrypted passphrase live in memory only and are never written to disk or logs

Lock state and startup:

- when the passphrase is encrypted the pool boots LOCKED: block sync, the web dashboard, and the public API all work, but payouts and ADM notifications are paused until unlock
- in a terminal the pool prompts for the operator password on startup with masked input; under pm2/systemd (no TTY) it keeps running locked and waits for `adm-pool unlock`
- delegate/network startup is held until the interactive unlock is resolved, so it cannot exit the process while the operator is still typing the password
- a plain passphrase emits a startup warning recommending encryption

Payout and notification safety:

- a payout that falls due while locked is deferred, not lost: pending rewards stay in the database and are processed immediately on unlock, without waiting for the next cron tick
- ADM notifications require signing, so they are paused while locked; Slack keeps working and remains the reliable channel for lock alerts

`adm-pool` control CLI and `/api/health`:

- `adm-pool encrypt | unlock | lock | status` manages encryption and runtime lock state, talking to the running pool over a local Unix socket with owner-only (`0600`) permissions
- `unlock` checks the pool is reachable before prompting, so a stopped pool is reported immediately instead of after the password is typed
- `GET /api/health` returns a secret-free JSON snapshot for monitoring such as Zabbix, and `/api/config` exposes a `locked` flag for the dashboard

Frontend, docs, and tests:

- the dashboard shows `(waiting for password to unlock payouts…)` next to the delegate name while the pool is locked
- fixes deprecated/removed TypeScript options in `web/jsconfig.json` (`importsNotUsedAsValues` → `verbatimModuleSyntax`, `moduleResolution` → `Bundler`, drops unused `baseUrl`)
- documents the workflow in `README.md` and `config.default.jsonc`, and adds round-trip, wrong-password, tamper, and detection tests for the crypto helper

## Related issue

Closes #12

## External links (optional)

- Issue #12: https://github.com/Adamant-im/pool/issues/12
- Upstream node issue: https://github.com/Adamant-im/adamant/issues/247

## Screenshots or videos (optional)

Dashboard while locked, next to the delegate name:

```text
Delegate noisy_pool (waiting for password to unlock payouts…) distributes 80% rewards to voters …
```

## Breaking changes

No intentional breaking changes.

- A plain `passPhrase` continues to work with no migration. Encryption is opt-in.
- A new optional `controlSocket` config field is added; when empty, the socket path is derived from the pool port.
- `/api/config` gains an additive `locked` boolean. No existing field is removed or changed.

## How to test

```sh
npm --prefix server run lint
npm --prefix server test
npm --prefix web run lint
npm --prefix web run build
git diff --check
```

Manual control flow:

```sh
npm run adm-pool encrypt        # paste the admpool-enc-v1.… value into config as passPhrase
npm start                       # in a terminal: prompts for the operator password
# or, under pm2 (no TTY): starts LOCKED, then from another shell:
npm run adm-pool status
npm run adm-pool unlock
npm run adm-pool lock
curl http://localhost:36667/api/health
```

Expected result: all validation commands pass. Local run: server lint clean and 69 tests passing across 9 suites; web lint clean and `vite build` succeeds.

## Notes for reviewers

Secret safety:

- the operator password and decrypted passphrase exist only in process memory; only the public key and address are embedded in the encrypted blob, and both are already public on-chain
- the control socket is local-only with `0600` permissions and accepts no network unlock; no secret is logged at any level
- a wrong password or tampered blob is rejected by GCM authentication and by re-deriving and comparing the public key

Payout safety:

- the only signing paths (`pay_out.js`, `notify.js`) now read the passphrase through the secret store and no-op while locked; a deferred scheduled payout is replayed once, immediately on unlock
- payout accounting (`pending - FEE`, `received`, retries) is unchanged; the lock only gates whether signing is allowed

Compatibility and reliability:

- plain passphrase detection and the existing keypair derivation path are unchanged
- node failover and locked-state handling keep the pool serving read-only data while waiting for unlock

## Checklist

- [x] Code is formatted
- [x] Tests added/updated (if needed)
- [x] Documentation updated (if needed)
- [x] Changes tested in all relevant environments
